### PR TITLE
fix: plan sheet — child row alignment/selection, hide empty archived rows

### DIFF
--- a/web/src/features/budgets/PlanSheet.test.tsx
+++ b/web/src/features/budgets/PlanSheet.test.tsx
@@ -540,7 +540,7 @@ it('Enter opens the editor on an editable cell and is inert on read-only cells',
   await user.keyboard('{Enter}')
   expect(screen.queryByLabelText('Budget')).not.toBeInTheDocument()
 
-  // children never carry their own limit
+  // children never carry their own limit (and are not selectable at all)
   const pe1Row = document.querySelector('[data-row-id="pe1:0"]') as HTMLElement
   await user.click(within(pe1Row).getByText('Living'))
   const childCell = await screen.findByTestId('plan-cell-cat-rent:1')
@@ -716,17 +716,35 @@ it('Enter on a highlighted envelope, category, or tag opens its edit dialog when
   await waitFor(() => expect(tagBody).toMatchObject({ id: 'tag1', name: 'vacation' }))
 })
 
-it('Enter on a highlighted child category opens the category dialog too', async () => {
+// Only rows that can carry a limit — envelopes, root categories, tags — are selectable.
+// An expanded envelope's children are read-only breakdown lines: a click on one does
+// not move the highlight, and the arrow keys step straight over them.
+it('child rows are not selectable by click or keyboard', async () => {
   usePlanHandlers()
   useBudgetPeriodStore.setState({ planFirstMonth: '2026-06-01', foldBudgetId: 'b1', unfoldedElements: { pe1: true } })
   const user = userEvent.setup()
   renderPage()
-  await screen.findByTestId('plan-cell-cat-rent:0')
+  const childCell = await screen.findByTestId('plan-cell-cat-rent:0')
+  const grid = screen.getByTestId('plan-sheet')
+  const childRow = childCell.closest('[role="row"]') as HTMLElement
+  const parentCell = screen.getByTestId('plan-cell-pe1:0')
 
-  await selectNameCell(user, 'cat-rent:1')
-  await user.keyboard('{Enter}')
-  const dialog = await screen.findByRole('dialog', { name: 'Edit category' })
-  expect(within(dialog).getByDisplayValue('Rent')).toBeInTheDocument()
+  await user.click(parentCell)
+  expect(parentCell).toHaveAttribute('aria-selected', 'true')
+
+  // clicking a child cell leaves the parent highlighted; child cells never expose aria-selected
+  await user.click(childCell)
+  expect(parentCell).toHaveAttribute('aria-selected', 'true')
+  for (const cell of within(childRow).getAllByRole('gridcell')) {
+    expect(cell).not.toHaveAttribute('aria-selected')
+  }
+
+  // ArrowDown from the expanded parent skips its children and lands on the next root row
+  grid.focus()
+  await user.keyboard('{ArrowDown}')
+  expect(screen.getByTestId('plan-cell-cat-food:0')).toHaveAttribute('aria-selected', 'true')
+  await user.keyboard('{ArrowUp}')
+  expect(parentCell).toHaveAttribute('aria-selected', 'true')
 })
 
 it('Enter without the right to edit explains why in a toast instead of opening a dialog: guest role for envelopes, foreign owner for categories/tags; uncategorized stays silent', async () => {
@@ -1521,6 +1539,15 @@ it('gives expanded child rows the same row-hover treatment as their parents', as
   // budget mode tints child rows on hover just like parents (BudgetTable.tsx);
   // plan mode must not diverge
   expect(childRow.className).toContain('plan-row')
+
+  // the child row's grid must share the parent row's horizontal padding — the fixed
+  // name column absorbs the indent, so the month cells line up under the parent's
+  // (extra padding on the row itself would shrink the 1fr month tracks and shift them)
+  const parentRow = screen.getByTestId('plan-cell-pe1:0').closest('[role="row"]') as HTMLElement
+  expect(parentRow.className).toContain('px-2')
+  expect(childRow.className).toContain('px-2')
+  expect(childRow.className).not.toMatch(/\bpl-\d/)
+  expect(childRow.style.gridTemplateColumns).toBe(parentRow.style.gridTemplateColumns)
 })
 
 it('shows plan row actions only in edit mode, with side-filtered move-to-folder', async () => {

--- a/web/src/features/budgets/PlanSheet.test.tsx
+++ b/web/src/features/budgets/PlanSheet.test.tsx
@@ -747,6 +747,57 @@ it('child rows are not selectable by click or keyboard', async () => {
   expect(parentCell).toHaveAttribute('aria-selected', 'true')
 })
 
+// The archive is history, not a workspace: an archived row shows only when it has a
+// value — a nonzero actual or a set plan — in a VISIBLE month, and the whole section
+// goes when none does. Values in the fetched-but-offscreen buffer months don't count,
+// so paging the window can hide or reveal a row. Same rule as the budget view's
+// Archive section, and independent of the density toggle.
+it('archived rows show only with a value in a visible month; the section disappears otherwise', async () => {
+  const archived = (id: string, name: string, cells: { actual: string; planned: string }[]) => ({
+    id, type: 1, name, icon: 'delete', currencyId: 'cur-usd', isArchived: 1, folderId: null, position: 9, ownerUserId: 'u1', cells, children: [],
+  })
+  const plan = {
+    ...fixtureWirePlan,
+    structure: {
+      ...fixtureWirePlan.structure,
+      elements: [
+        ...fixtureWirePlan.structure.elements,
+        // fixture months are May..Aug; the initial window below is Jun..Aug, so May is a buffer month
+        archived('arch-may', 'Only May', [{ actual: '18.53', planned: '' }, { actual: '0', planned: '' }, { actual: '0', planned: '' }, { actual: '0', planned: '' }]),
+        archived('arch-aug', 'Only Aug', [{ actual: '0', planned: '' }, { actual: '0', planned: '' }, { actual: '0', planned: '' }, { actual: '0', planned: '40' }]),
+        archived('arch-none', 'Nothing', [{ actual: '0', planned: '' }, { actual: '0.00', planned: '' }, { actual: '0', planned: '' }, { actual: '0', planned: '' }]),
+      ],
+    },
+  }
+  server.use(
+    ...coreHandlers({ user: userWithBudget }),
+    http.get('*/api/v1/budget/get-budget', () => HttpResponse.json({ success: true, message: '', data: { item: fixtureWireBudget } })),
+    planHandler(plan),
+  )
+  useBudgetPeriodStore.setState({ planFirstMonth: '2026-06-01' })
+  const user = userEvent.setup()
+  renderPage()
+  await screen.findByTestId('plan-sheet')
+
+  // Jun..Aug: only the row with an August plan has a visible value
+  const section = await screen.findByTestId('plan-section-archived')
+  expect(within(section).getByTitle('Only Aug')).toBeInTheDocument()
+  expect(within(section).queryByTitle('Only May')).not.toBeInTheDocument()
+  expect(within(section).queryByTitle('Nothing')).not.toBeInTheDocument()
+
+  // May..Jul: the May spend comes on screen, the August plan leaves it
+  await user.click(screen.getByRole('button', { name: 'Earlier months' }))
+  await waitFor(() => expect(within(screen.getByTestId('plan-section-archived')).getByTitle('Only May')).toBeInTheDocument())
+  expect(within(screen.getByTestId('plan-section-archived')).queryByTitle('Only Aug')).not.toBeInTheDocument()
+
+  // a window with no archived values at all drops the section entirely: Sep..Nov
+  // (only May and Aug carry values, and neither is visible then)
+  for (let i = 0; i < 4; i++) {
+    await user.click(screen.getByRole('button', { name: 'Later months' }))
+  }
+  await waitFor(() => expect(screen.queryByTestId('plan-section-archived')).not.toBeInTheDocument())
+})
+
 it('Enter without the right to edit explains why in a toast instead of opening a dialog: guest role for envelopes, foreign owner for categories/tags; uncategorized stays silent', async () => {
   const guestAccess = [{ user: fixtureOwner, role: 'guest', isAccepted: 1 }]
   const guestBudget = { ...fixtureWireBudget, meta: { ...fixtureWireBudget.meta, access: guestAccess } }

--- a/web/src/features/budgets/PlanSheet.tsx
+++ b/web/src/features/budgets/PlanSheet.tsx
@@ -359,6 +359,11 @@ function PlanSortableFolder({ section, children }: { section: PlanFolderSection;
   )
 }
 
+// A child is a read-only breakdown of its parent's actuals: it carries no limit and
+// is not selectable (no aria-selected, no click/keyboard target) — only rows a limit
+// can be set on take the highlight. The indent lives INSIDE the fixed-width name
+// cell: padding on the row itself would eat into the 1fr month tracks and shift the
+// child's figures out from under the parent's.
 const ChildRow = memo(function ChildRow({
   child,
   parentCurrency,
@@ -371,22 +376,14 @@ const ChildRow = memo(function ChildRow({
   const { t } = useTranslation()
   const displayName = elementDisplayName(child.id, child.name, t)
   const rk = `${child.id}:${child.type}`
-  const nameSelected = ctx.selection?.rowKey === rk && ctx.selection.col === -1
   return (
     <div
       role="row"
       data-row-id={rk}
-      className="plan-row grid items-stretch gap-1 py-1 pr-2 pl-9 text-xs text-muted-foreground"
+      className="plan-row grid items-stretch gap-1 px-2 py-1 text-xs text-muted-foreground"
       style={{ gridTemplateColumns: ctx.gridCols }}
     >
-      <span
-        role="gridcell"
-        id={cellDomId(rk, -1)}
-        aria-selected={nameSelected}
-        className={`flex h-full min-w-0 items-center gap-1.5 truncate${selectedClass(nameSelected)}`}
-        title={displayName}
-        onClick={(e) => ctx.select(rk, -1, e)}
-      >
+      <span role="gridcell" className="flex h-full min-w-0 items-center gap-1.5 truncate pl-7" title={displayName}>
         <EntityIcon name={child.icon} className="text-base" />
         <span className="min-w-0 flex-1 truncate">{displayName}</span>
       </span>
@@ -394,19 +391,15 @@ const ChildRow = memo(function ChildRow({
         const idx = ctx.monthIndex(m)
         const cell = idx >= 0 ? child.cells[idx] : undefined
         const actualText = renderActual(cell?.actual, m, ctx.cur, parentCurrency)
-        const selected = ctx.selection?.rowKey === rk && ctx.selection.col === i
         return (
           <div
             key={m}
             role="gridcell"
-            id={cellDomId(rk, i)}
-            aria-selected={selected}
             aria-label={t('budgets.page.plan.cell.aria', { name: displayName, month: ctx.monthLabel(m), actual: actualText, planned: '—' })}
             data-month={m}
             data-col={i}
             data-testid={`plan-cell-${child.id}:${i}`}
-            className={`flex items-center justify-end px-2 py-1 ${selectedClass(selected)}`}
-            onClick={(e) => ctx.select(rk, i, e)}
+            className="flex items-center justify-end px-2 py-1"
           >
             <span data-testid="cell-actual">{actualText}</span>
           </div>
@@ -893,29 +886,19 @@ function PlanBalanceRow({
 
 
 // Same flattening the renderer walks (folders -> loose, income then expense, then
-// archived), so Up/Down can never reach a row that isn't on screen. The uncategorized
-// expense figure is excluded: it renders as a totals line, not a selectable row.
+// archived), so Up/Down can never reach a row that isn't on screen. Only root rows —
+// the ones a limit can be set on — are in the order: an expanded envelope's children
+// are read-only breakdown lines and are stepped over. The uncategorized expense
+// figure is excluded too: it renders as a totals line, not a selectable row.
 interface FlatRow {
   rowKey: string
   el: PlanElementDto
-  child?: PlanChildDto
 }
 
-function buildFlatRows(
-  rows: PlanRows,
-  unfoldedElements: Record<string, boolean>,
-  hideEmpty: boolean,
-  revealedSections: Set<string>,
-  folded: (key: string) => boolean,
-): FlatRow[] {
+function buildFlatRows(rows: PlanRows, hideEmpty: boolean, revealedSections: Set<string>, folded: (key: string) => boolean): FlatRow[] {
   const flatRows: FlatRow[] = []
   const pushRow = (r: PlanRow) => {
     flatRows.push({ rowKey: rowKey(r), el: r.element })
-    if (r.element.children.length > 0 && unfoldedElements[r.element.id]) {
-      for (const child of r.element.children) {
-        flatRows.push({ rowKey: `${child.id}:${child.type}`, el: r.element, child })
-      }
-    }
   }
   const incomeFolded = folded('income')
   if (!incomeFolded) {
@@ -1072,7 +1055,6 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
   const planFolds = useBudgetPeriodStore((s) => s.planFolds)
   const togglePlanFold = useBudgetPeriodStore((s) => s.togglePlanFold)
   const folded = useCallback((key: string): boolean => !!planFolds[key], [planFolds])
-  const unfoldedElements = useBudgetPeriodStore((s) => s.unfoldedElements)
   const toggleElement = useBudgetPeriodStore((s) => s.toggleElement)
   const [selection, setSelection] = useState<PlanSelection | null>(null)
   const [fillDrag, setFillDrag] = useState<FillDrag | null>(null)
@@ -1262,8 +1244,8 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
   const totals = useMemo(() => (plan && ex ? planTotals(plan, ex) : []), [plan, ex])
   const balance = useMemo(() => (plan && ex ? balanceRow(plan, totals, ex) : []), [plan, ex, totals])
   const flatRows = useMemo(
-    () => (shownRows ? buildFlatRows(shownRows, unfoldedElements, hideEmpty, revealedSections, folded) : []),
-    [shownRows, unfoldedElements, hideEmpty, revealedSections, folded],
+    () => (shownRows ? buildFlatRows(shownRows, hideEmpty, revealedSections, folded) : []),
+    [shownRows, hideEmpty, revealedSections, folded],
   )
   const folderSideMap = useMemo(() => (plan ? folderSides(plan) : new Map<Id, FolderSide>()), [plan])
 
@@ -1452,7 +1434,7 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
   // row ownership for a category or tag — update-category/update-tag answer anyone
   // but the owner with NotFound, so a shared row must not offer the dialog at all.
   function openElementEditor(entry: FlatRow) {
-    const target = entry.child ?? entry.el
+    const target = entry.el
     if (target.id === UNCATEGORIZED_ID) {
       return
     }
@@ -1485,9 +1467,6 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
   function handleEnter(entry: FlatRow, col: number) {
     if (col === -1) {
       openElementEditor(entry)
-      return
-    }
-    if (entry.child) {
       return
     }
     const month = visibleMonths[col]
@@ -1598,7 +1577,7 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
         if (selection.col === -1) {
           e.preventDefault()
           const entry = flatRows[idx]
-          if (!entry.child && entry.el.children.length > 0) {
+          if (entry.el.children.length > 0) {
             toggleElement(entry.el.id)
           }
         }

--- a/web/src/features/budgets/PlanSheet.tsx
+++ b/web/src/features/budgets/PlanSheet.tsx
@@ -23,7 +23,7 @@ import { ResponsiveDialog } from '@/components/ResponsiveDialog'
 import { cmp, isZero } from '@/lib/decimal'
 import { moneyFormat } from '@/lib/money'
 import { isNotEmpty, isValidBudgetFolderName } from '@/lib/validation'
-import type { BudgetDto, BudgetFolderDto, BudgetMetaDto, BudgetPlanDto, PlanChildDto, PlanElementDto } from '@/api/dto/budget'
+import type { BudgetDto, BudgetFolderDto, BudgetMetaDto, BudgetPlanDto, PlanCellDto, PlanChildDto, PlanElementDto } from '@/api/dto/budget'
 import { BudgetElementType, isIncomeType, UNCATEGORIZED_ID } from '@/api/dto/budget'
 import type { CategoryDto } from '@/api/dto/category'
 import type { CurrencyDto } from '@/api/dto/currency'
@@ -1213,26 +1213,31 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
     return bucketPlanRows({ ...plan, structure }, false)
   }, [plan, dragArrangement])
 
-  // An uncategorized row is dropped when every VISIBLE column's actual is zero — it
-  // can still have spend outside the current window, so it reappears once navigation
-  // brings that month into view. Derived once here (not per-section, not in
-  // buildFlatRows) so the render sections and the keyboard flat-row list can never
-  // disagree on which rows are on screen.
+  // Rows that earn their place per VISIBLE window, not per fetched cells (the fetch
+  // carries buffer months either side): an uncategorized row is dropped when every
+  // visible column's actual is zero, and an archived row when no visible column has
+  // an actual or a plan — the archive is history, so an all-dash row there is noise
+  // (the budget view's Archive section applies the same rule per month). Both can
+  // still have values outside the window, so they reappear once navigation brings
+  // that month into view. Derived once here (not per-section, not in buildFlatRows)
+  // so the render sections and the keyboard flat-row list can never disagree on
+  // which rows are on screen.
   const shownRows = useMemo(() => {
     if (!rows) {
       return null
     }
-    const visibleUncat = (r: PlanRow | null): PlanRow | null =>
-      r && visibleMonths.some((m) => {
+    const hasVisible = (r: PlanRow, test: (c: PlanCellDto) => boolean): boolean =>
+      visibleMonths.some((m) => {
         const i = monthIndex(m)
-        return i >= 0 && !isZero(r.element.cells[i]?.actual ?? '0')
+        const c = i >= 0 ? r.element.cells[i] : undefined
+        return c !== undefined && test(c)
       })
-        ? r
-        : null
+    const visibleUncat = (r: PlanRow | null): PlanRow | null => (r && hasVisible(r, (c) => !isZero(c.actual)) ? r : null)
     return {
       ...rows,
       income: { ...rows.income, uncategorized: visibleUncat(rows.income.uncategorized) },
       expense: { ...rows.expense, uncategorized: visibleUncat(rows.expense.uncategorized) },
+      archived: rows.archived.filter((r) => hasVisible(r, (c) => !isZero(c.actual) || c.planned !== '')),
     }
   }, [rows, visibleMonths, monthIndex])
 


### PR DESCRIPTION
## What changed

Three fixes to the budget **Plan** sheet (`web/src/features/budgets/PlanSheet.tsx`):

1. **Child rows align under the parent.** An expanded envelope's child rows put their indent on the grid row itself (`pl-9` vs the parent's `px-2`), which squeezed the `1fr` month tracks and shifted every child figure ~28px right of the parent's. The indent now lives inside the fixed-width name cell, so the month cells line up to the pixel.
2. **Child rows are not selectable.** Only rows a limit can be set on — envelopes, root categories, tags — take the highlight. Children are read-only breakdown lines: no `aria-selected` / click target on their cells, and Up/Down step straight over them to the next root row. The dead `child` branches in the Enter/Space handlers and `FlatRow.child` go with it. (Enter-on-a-child no longer opens the category dialog; children remain editable from their settings page / the envelope dialog.)
3. **Archived rows with no value in the visible window are hidden**, and the Archived section disappears when nothing qualifies. The budget view already does this per selected month (`budgetMath.bucketElements`); the plan sheet now applies the same rule — a nonzero actual or a set plan in a **visible** column — in `shownRows`, next to the existing uncategorized-row rule, so render and keyboard order stay in step.

## Why the visible window, not the fetched cells

`useBudgetPlan` fetches ±2 buffer months around the visible window (`planFetchWindow`), so filtering on `el.cells` kept an archived row on screen when its only spend sat in a buffer month. Filtering per visible column matches the "selected interval" semantics and means paging the window hides/reveals rows.

## Tests

- new: `child rows are not selectable by click or keyboard`
- new: `archived rows show only with a value in a visible month; the section disappears otherwise` (three windows via the Earlier/Later buttons)
- alignment assertions added to the existing child-row hover test
- removed: `Enter on a highlighted child category opens the category dialog too` (behaviour intentionally dropped, see 2)

Full web suite 1068/1068, oxlint + tsc clean. Verified live on the demo budget with a temporary envelope and two temporarily archived categories (all restored afterwards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)