### PR TITLE
feat: plan sheet — keyboard fold/unfold, selectable folders, hover fill handle

### DIFF
--- a/docs/superpowers/specs/2026-08-16-plan-keyboard-fold-hover-fill-design.md
+++ b/docs/superpowers/specs/2026-08-16-plan-keyboard-fold-hover-fill-design.md
@@ -1,0 +1,68 @@
+# Plan view: keyboard fold/unfold, selectable folders, hover fill handle
+
+**Date:** 2026-08-16 · **Branch:** `feature/plan-sheet-keyboard-fold-hover-fill` · **Scope:** `web/` only
+
+## Problem
+
+Two friction points in the plan sheet (`web/src/features/budgets/PlanSheet.tsx`):
+
+1. Folding is mouse-only and coarse. An envelope's whole name (chevron + icon +
+   text) is one button, so a click meant to highlight the row springs its
+   breakdown open; the keyboard reaches an envelope's name cell but can only
+   toggle it with Space, and a folder header is not reachable at all.
+2. The fill handle (the corner dot that drags a plan value across months) only
+   renders on the *selected* cell, so copying a value costs a click first.
+
+## Rules
+
+### Folding by keyboard
+
+- **Envelope name click selects only.** Just the chevron button (with
+  `aria-expanded` and the Expand/Collapse title) toggles the children.
+- On a **highlighted name cell (col −1) of a row with children**:
+  `ArrowRight` unfolds a collapsed row — only when already unfolded does it move
+  to the first month; `ArrowLeft` folds an unfolded row — only when already
+  collapsed does it page the window back (the existing behaviour). Rows without
+  children navigate exactly as before. Space keeps toggling.
+- **Folder headers are selectable rows.** Clicking the header still folds/unfolds
+  (as today) and additionally selects it (`pfolder:<id>` in the selection's
+  rowKey space). On a highlighted folder: `ArrowRight` unfolds when folded,
+  `ArrowLeft` folds when unfolded (each a no-op otherwise — no window paging),
+  `Enter`/`Space` toggle. `ArrowUp`/`ArrowDown` walk headers and rows in visual
+  order and keep the selection's column, so a trip through a header lands back
+  on the same month. Neutral (member-less) folders are in the order too.
+- The header cell carries the same selection ring/`aria-selected` as a name
+  cell; `aria-activedescendant` and the scroll-into-view logic resolve a folder
+  selection to its single (−1) cell.
+
+### Fill handle on hover
+
+- The handle also renders on an **editable month cell under the mouse**, whether
+  or not another cell is selected (and when nothing is). Same gates as before
+  otherwise (editable, fetched cell, not compact, >1 visible month).
+- The in-flight drag's **source cell keeps its handle mounted** after the pointer
+  leaves it (the handle holds the pointer capture; unmounting it would drop the
+  `pointerup` that commits the fill).
+- **On release, the source cell becomes the selection** (and the grid takes
+  focus), so the keyboard picks up where the mouse left.
+
+## Implementation
+
+- `FlatRow` becomes a `kind: 'element' | 'folder'` union; `buildFlatRows` pushes a
+  folder entry before each folder's visible members (income, neutral, expense).
+- `handleKeyDown` branches on `entry.kind`; the element branch consults
+  `unfoldedElements` for the name-cell Left/Right fold rule.
+- `FolderRows` gets `role="row"` on the header, a `role="gridcell"` name group
+  with the selection id/ring, and calls `ctx.select` on both click paths.
+- `ElementRow` keeps a row-local `hoverCol` state (`onMouseEnter`/`onMouseLeave`
+  per month cell) so a hover re-renders one row, not the grid; `fillEnd` calls
+  `select(rowKey, startCol)`.
+
+## Tests
+
+`PlanSheet.test.tsx`: name click selects without expanding / chevron toggles;
+ArrowRight/ArrowLeft fold rules on an envelope name cell; folder header
+selection + fold keys + column preservation; hover handle presence, survival of
+the drag source, and source selection after the drag. Existing tests that
+expanded by clicking the name text now click the chevron, and the keyboard-order
+tests account for the folder header entry.

--- a/web/src/features/budgets/PlanSheet.test.tsx
+++ b/web/src/features/budgets/PlanSheet.test.tsx
@@ -432,7 +432,7 @@ it('uncategorized and child cells are not editable; guest role sees no editors',
 
   // children never carry their own limit, regardless of role
   const pe1Row = document.querySelector('[data-row-id="pe1:0"]') as HTMLElement
-  await user.click(within(pe1Row).getByText('Living'))
+  await user.click(within(pe1Row).getByRole('button', { name: 'Expand' }))
   const childCell = await screen.findByTestId('plan-cell-cat-rent:1')
   expect(within(childCell).queryByRole('button')).not.toBeInTheDocument()
 
@@ -492,8 +492,12 @@ it('arrow keys move the selection and shift the window at the edges', async () =
   const pe1Row = document.querySelector('[data-row-id="pe1:0"]') as HTMLElement
   expect(within(pe1Row).getByTitle('Living').closest('[role="gridcell"]')).toHaveAttribute('aria-selected', 'true')
 
-  // ArrowRight returns to the first month column of the now-shifted window
+  // ArrowRight on the name cell of a row with children first unfolds it (pe1/Living
+  // has a child); the next ArrowRight returns to the first month column of the
+  // now-shifted window
   grid.focus()
+  await user.keyboard('{ArrowRight}')
+  expect(await screen.findByTestId('plan-cell-cat-rent:0')).toBeInTheDocument()
   await user.keyboard('{ArrowRight}')
   expect(await screen.findByTestId('plan-cell-pe1:0')).toHaveAttribute('data-month', '2026-05-01')
   expect(screen.getByTestId('plan-cell-pe1:0')).toHaveAttribute('aria-selected', 'true')
@@ -542,7 +546,7 @@ it('Enter opens the editor on an editable cell and is inert on read-only cells',
 
   // children never carry their own limit (and are not selectable at all)
   const pe1Row = document.querySelector('[data-row-id="pe1:0"]') as HTMLElement
-  await user.click(within(pe1Row).getByText('Living'))
+  await user.click(within(pe1Row).getByRole('button', { name: 'Expand' }))
   const childCell = await screen.findByTestId('plan-cell-cat-rent:1')
   await user.click(childCell)
   grid.focus()
@@ -635,6 +639,127 @@ it('ArrowLeft reaches the name cell (col -1) by keyboard, Space there toggles ex
   await user.keyboard('{ArrowLeft}')
   await waitFor(() => expect(useBudgetPeriodStore.getState().planFirstMonth).toBe('2026-05-01'))
   expect(within(pe1Row).getByTitle('Living').closest('[role="gridcell"]')).toHaveAttribute('aria-selected', 'true')
+})
+
+// The name is a selection target, not a fold toggle: only the chevron unfolds the
+// children, so a click meant to highlight the row never springs the breakdown open.
+it('clicking an envelope name selects it without expanding; only the chevron toggles the children', async () => {
+  usePlanHandlers()
+  useBudgetPeriodStore.setState({ planFirstMonth: '2026-06-01' })
+  const user = userEvent.setup()
+  renderPage()
+  await screen.findByTestId('plan-sheet')
+  const pe1Row = document.querySelector('[data-row-id="pe1:0"]') as HTMLElement
+  const nameCell = within(pe1Row).getByTitle('Living').closest('[role="gridcell"]') as HTMLElement
+
+  await user.click(within(pe1Row).getByTitle('Living'))
+  expect(nameCell).toHaveAttribute('aria-selected', 'true')
+  expect(screen.queryByTestId('plan-cell-cat-rent:0')).not.toBeInTheDocument()
+
+  const chevron = within(pe1Row).getByRole('button', { name: 'Expand' })
+  expect(chevron).toHaveAttribute('aria-expanded', 'false')
+  await user.click(chevron)
+  expect(await screen.findByTestId('plan-cell-cat-rent:0')).toBeInTheDocument()
+  expect(within(pe1Row).getByRole('button', { name: 'Collapse' })).toHaveAttribute('aria-expanded', 'true')
+  await user.click(within(pe1Row).getByRole('button', { name: 'Collapse' }))
+  await waitFor(() => expect(screen.queryByTestId('plan-cell-cat-rent:0')).not.toBeInTheDocument())
+})
+
+it('ArrowRight on a collapsed envelope name cell expands it and ArrowLeft collapses it; otherwise the keys navigate as before', async () => {
+  usePlanHandlers()
+  useBudgetPeriodStore.setState({ planFirstMonth: '2026-06-01' })
+  const user = userEvent.setup()
+  renderPage()
+  await screen.findByTestId('plan-sheet')
+  const grid = screen.getByTestId('plan-sheet')
+  const pe1Row = document.querySelector('[data-row-id="pe1:0"]') as HTMLElement
+  const nameCell = within(pe1Row).getByTitle('Living').closest('[role="gridcell"]') as HTMLElement
+
+  await user.click(screen.getByTestId('plan-cell-pe1:0'))
+  grid.focus()
+  await user.keyboard('{ArrowLeft}')
+  expect(nameCell).toHaveAttribute('aria-selected', 'true')
+
+  // collapsed + ArrowRight: expand, selection stays on the name cell
+  await user.keyboard('{ArrowRight}')
+  expect(await screen.findByTestId('plan-cell-cat-rent:0')).toBeInTheDocument()
+  expect(nameCell).toHaveAttribute('aria-selected', 'true')
+  // expanded + ArrowRight: the usual move to the first month column
+  await user.keyboard('{ArrowRight}')
+  expect(screen.getByTestId('plan-cell-pe1:0')).toHaveAttribute('aria-selected', 'true')
+  expect(screen.getByTestId('plan-cell-cat-rent:0')).toBeInTheDocument()
+
+  await user.keyboard('{ArrowLeft}')
+  expect(nameCell).toHaveAttribute('aria-selected', 'true')
+  // expanded + ArrowLeft: collapse, the window does not page
+  await user.keyboard('{ArrowLeft}')
+  await waitFor(() => expect(screen.queryByTestId('plan-cell-cat-rent:0')).not.toBeInTheDocument())
+  expect(nameCell).toHaveAttribute('aria-selected', 'true')
+  expect(useBudgetPeriodStore.getState().planFirstMonth).toBe('2026-06-01')
+  // collapsed + ArrowLeft: pages the window back as before
+  await user.keyboard('{ArrowLeft}')
+  await waitFor(() => expect(useBudgetPeriodStore.getState().planFirstMonth).toBe('2026-05-01'))
+
+  // a row without children never folds on ArrowRight/ArrowLeft — plain navigation
+  await user.click(screen.getByTestId('plan-cell-cat-food:0'))
+  grid.focus()
+  await user.keyboard('{ArrowLeft}{ArrowRight}')
+  expect(screen.getByTestId('plan-cell-cat-food:0')).toHaveAttribute('aria-selected', 'true')
+})
+
+it('folder headers are selectable: ArrowLeft/ArrowRight fold/unfold them, Up/Down step through them keeping the column', async () => {
+  usePlanHandlers()
+  useBudgetPeriodStore.setState({ planFirstMonth: '2026-06-01' })
+  const user = userEvent.setup()
+  renderPage()
+  await screen.findByTestId('plan-sheet')
+  const grid = screen.getByTestId('plan-sheet')
+  const folder = screen.getByTestId('plan-folder-bf1')
+  const nameButton = within(folder).getByRole('button', { name: 'Essentials' })
+  const headerCell = nameButton.closest('[role="gridcell"]') as HTMLElement
+  const header = nameButton.parentElement!.parentElement as HTMLElement
+
+  // clicking the header row still folds (as before) AND selects the folder
+  await user.click(header)
+  expect(document.querySelector('[data-row-id="pe1:0"]')).not.toBeInTheDocument()
+  expect(headerCell).toHaveAttribute('aria-selected', 'true')
+
+  // ArrowRight unfolds a folded folder; a second ArrowRight is a no-op
+  grid.focus()
+  await user.keyboard('{ArrowRight}')
+  expect(document.querySelector('[data-row-id="pe1:0"]')).toBeInTheDocument()
+  expect(headerCell).toHaveAttribute('aria-selected', 'true')
+  await user.keyboard('{ArrowRight}')
+  expect(document.querySelector('[data-row-id="pe1:0"]')).toBeInTheDocument()
+  expect(headerCell).toHaveAttribute('aria-selected', 'true')
+  expect(useBudgetPeriodStore.getState().planFirstMonth).toBe('2026-06-01')
+
+  // ArrowDown lands on the folder's first member row (name column, where the click put it)
+  await user.keyboard('{ArrowDown}')
+  const pe1Row = document.querySelector('[data-row-id="pe1:0"]') as HTMLElement
+  expect(within(pe1Row).getByTitle('Living').closest('[role="gridcell"]')).toHaveAttribute('aria-selected', 'true')
+  await user.keyboard('{ArrowUp}')
+  expect(headerCell).toHaveAttribute('aria-selected', 'true')
+
+  // ArrowLeft folds an unfolded folder; a second ArrowLeft is a no-op (no window paging)
+  await user.keyboard('{ArrowLeft}')
+  expect(document.querySelector('[data-row-id="pe1:0"]')).not.toBeInTheDocument()
+  await user.keyboard('{ArrowLeft}')
+  expect(document.querySelector('[data-row-id="pe1:0"]')).not.toBeInTheDocument()
+  expect(useBudgetPeriodStore.getState().planFirstMonth).toBe('2026-06-01')
+  // Space toggles it back open
+  await user.keyboard(' ')
+  expect(document.querySelector('[data-row-id="pe1:0"]')).toBeInTheDocument()
+
+  // the column survives a trip through the header: Up from pe1's Jul cell selects
+  // the folder, Down comes back to the same Jul cell
+  await user.click(screen.getByTestId('plan-cell-pe1:1'))
+  grid.focus()
+  await user.keyboard('{ArrowUp}')
+  expect(headerCell).toHaveAttribute('aria-selected', 'true')
+  expect(screen.getByTestId('plan-cell-pe1:1')).not.toHaveAttribute('aria-selected', 'true')
+  await user.keyboard('{ArrowDown}')
+  expect(screen.getByTestId('plan-cell-pe1:1')).toHaveAttribute('aria-selected', 'true')
 })
 
 // Enter on the highlighted name cell opens the element's own edit dialog — the same
@@ -1064,6 +1189,64 @@ describe('fill handle', () => {
     expect(screen.getByTestId('plan-cell-pe1:2')).toContainElement(screen.getByTestId('fill-handle'))
   })
 
+  it('renders on a hovered editable cell while another cell is selected, and a drag from it selects the source cell', async () => {
+    const bodies: unknown[] = []
+    server.use(
+      ...coreHandlers({ user: userWithBudget }),
+      http.get('*/api/v1/budget/get-budget', () => HttpResponse.json({ success: true, message: '', data: { item: fixtureWireBudget } })),
+      planHandler(),
+      http.post('*/api/v1/budget/set-limit', async ({ request }) => {
+        bodies.push(await request.json())
+        await delay('infinite')
+        return HttpResponse.json({ success: true, message: '', data: {} })
+      }),
+    )
+    useBudgetPeriodStore.setState({ planFirstMonth: '2026-06-01' })
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('plan-sheet')
+
+    // nothing selected yet: hovering an editable cell already offers the handle
+    const pe1Jul = screen.getByTestId('plan-cell-pe1:1')
+    await user.hover(pe1Jul)
+    expect(within(pe1Jul).getByTestId('fill-handle')).toBeInTheDocument()
+    await user.unhover(pe1Jul)
+    expect(screen.queryByTestId('fill-handle')).not.toBeInTheDocument()
+
+    // select tag1's Jun cell, then hover pe1's Jul cell: the hovered cell offers the
+    // handle without stealing the selection
+    const tag1Jun = screen.getByTestId('plan-cell-tag1:0')
+    await user.click(tag1Jun)
+    expect(within(tag1Jun).getByTestId('fill-handle')).toBeInTheDocument()
+    await user.hover(pe1Jul)
+    expect(tag1Jun).toHaveAttribute('aria-selected', 'true')
+    expect(within(pe1Jul).getByTestId('fill-handle')).toBeInTheDocument()
+
+    // a non-editable cell offers nothing on hover
+    const uncat = screen.getAllByTestId('plan-cell-uncategorized:0')[0]
+    await user.hover(uncat)
+    expect(within(uncat).queryByTestId('fill-handle')).not.toBeInTheDocument()
+
+    // drag from the hovered cell's handle: the pointer leaves the source cell mid-drag,
+    // yet the handle (which holds the pointer capture) survives until release
+    await user.hover(pe1Jul)
+    const handle = within(pe1Jul).getByTestId('fill-handle')
+    fireEvent.pointerDown(handle, { clientX: 100, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientX: 210, pointerId: 1 })
+    fireEvent.mouseLeave(pe1Jul)
+    expect(screen.getByTestId('plan-cell-pe1:2').className).toContain('fill-covered')
+    expect(within(pe1Jul).getByTestId('fill-handle')).toBe(handle)
+    fireEvent.pointerUp(handle, { clientX: 210, pointerId: 1 })
+
+    await waitFor(() => expect(bodies).toHaveLength(1))
+    // pe1's Jul plan is 250 (fetched months May..Aug, index 2)
+    expect(bodies[0]).toEqual({ budgetId: 'b1', elementId: 'pe1', period: '2026-08-01', amount: '250' })
+    // once copied, the copied (source) cell is the selection
+    expect(pe1Jul).toHaveAttribute('aria-selected', 'true')
+    expect(tag1Jun).not.toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByTestId('plan-sheet')).toHaveFocus()
+  })
+
   it('dragging a cell with no limit set copies an explicit 0, not an empty amount', async () => {
     const bodies: unknown[] = []
     server.use(
@@ -1423,9 +1606,12 @@ describe('income/expense split', () => {
     expect(document.querySelector('[data-row-id="uncategorized:3"]')).not.toBeInTheDocument()
 
     // keyboard flat rows must skip it too: ArrowDown from the last income loose row
-    // (Freelance) lands on the first expense row, never on the hidden uncategorized row
+    // (Freelance) lands on the expense side (the Essentials folder header, then its
+    // first row), never on the hidden uncategorized row
     await user.click(screen.getByTestId('plan-cell-cat-freelance:0'))
     grid.focus()
+    await user.keyboard('{ArrowDown}')
+    expect(screen.getByRole('button', { name: 'Essentials' }).closest('[role="gridcell"]')).toHaveAttribute('aria-selected', 'true')
     await user.keyboard('{ArrowDown}')
     expect(screen.getByTestId('plan-cell-pe1:0')).toHaveAttribute('aria-selected', 'true')
 
@@ -1583,7 +1769,7 @@ it('gives expanded child rows the same row-hover treatment as their parents', as
   await screen.findByTestId('plan-sheet')
 
   // pe1/Living has children; expanding it reveals cat-rent as a ChildRow
-  await user.click(within(document.querySelector('[data-row-id="pe1:0"]') as HTMLElement).getByTitle('Living'))
+  await user.click(within(document.querySelector('[data-row-id="pe1:0"]') as HTMLElement).getByRole('button', { name: 'Expand' }))
   const childCell = await screen.findByTestId('plan-cell-cat-rent:0')
   const childRow = childCell.closest('[role="row"]') as HTMLElement
 
@@ -1803,7 +1989,7 @@ it('keeps the drag grip on its own root row, not stretched by expanded children'
   // expanding pe1/Living adds child rows INSIDE the same wrapper; the grip must not
   // be pulled to the middle of the whole expanded block
   expect(screen.queryByTestId('plan-cell-cat-rent:0')).not.toBeInTheDocument()
-  await user.click(within(wrapper).getByText('Living'))
+  await user.click(within(wrapper).getByRole('button', { name: 'Expand' }))
   expect(await screen.findByTestId('plan-cell-cat-rent:0')).toBeInTheDocument()
   const rootRow = wrapper.querySelector('[role="row"]') as HTMLElement
   expect(rootRow).toContainElement(screen.getByTestId('plan-cell-pe1:0'))

--- a/web/src/features/budgets/PlanSheet.tsx
+++ b/web/src/features/budgets/PlanSheet.tsx
@@ -91,11 +91,18 @@ export interface PlanSheetProps {
 }
 
 const rowKey = (r: PlanRow): string => `${r.element.id}:${r.element.type}`
+// A folder header is a selectable row of the grid too (fold/unfold by keyboard); it
+// shares the selection's rowKey space with the element rows under a distinct prefix.
+const folderRowKey = (folderId: Id): string => `pfolder:${folderId}`
+const isFolderRowKey = (rk: string): boolean => rk.startsWith('pfolder:')
 
 // A stable DOM id per gridcell, used by aria-activedescendant. rowKey already embeds
 // a ':' (id:type), which is valid in an HTML id but not worth relying on downstream, so
 // it's sanitized to a safe character set.
 const cellDomId = (rk: string, col: number): string => `plan-cell-${rk.replace(/[^a-zA-Z0-9_-]/g, '_')}-${col}`
+// A folder header has a single cell, so whatever column the selection carries (kept so
+// Up/Down through a header lands back on the same month), its DOM cell is the -1 one.
+const selectionDomId = (sel: PlanSelection): string => cellDomId(sel.rowKey, isFolderRowKey(sel.rowKey) ? -1 : sel.col)
 
 const SELECTED_RING = ' ring-2 ring-ring rounded-sm'
 const selectedClass = (selected: boolean): string => (selected ? SELECTED_RING : '')
@@ -137,7 +144,10 @@ interface PlanLimitTarget {
 /** roving grid selection: col -1 = the row's name cell, 0..visible-1 = month cells.
  *  -1 is the leftmost reachable column: ArrowRight there goes to 0, ArrowLeft at 0
  *  goes to -1, and ArrowLeft AT -1 shifts the window back a month (selection stays
- *  at -1) — the name cell is always reachable by keyboard alone. */
+ *  at -1) — the name cell is always reachable by keyboard alone. On a name cell with
+ *  children, ArrowRight/ArrowLeft first unfold/fold the breakdown and only then move
+ *  on. rowKey may also name a folder header (`pfolder:<id>`), which has just the
+ *  name cell but keeps whatever col the selection arrived with. */
 export interface PlanSelection {
   rowKey: string
   col: number
@@ -422,6 +432,10 @@ const ElementRow = memo(function ElementRow({ row, ctx }: { row: PlanRow; ctx: G
   const Chevron = unfolded ? ChevronDown : ChevronRight
   const rk = `${el.id}:${el.type}`
   const nameSelected = ctx.selection?.rowKey === rk && ctx.selection.col === -1
+  // The fill handle also shows on the month cell under the mouse, so a value can be
+  // dragged right without first clicking the cell to select it. Row-local state, so a
+  // hover re-renders this row only, never the grid.
+  const [hoverCol, setHoverCol] = useState<number | null>(null)
 
   const name = (
     <>
@@ -446,23 +460,25 @@ const ElementRow = memo(function ElementRow({ row, ctx }: { row: PlanRow; ctx: G
           className={`flex h-full min-w-0 items-center gap-1${selectedClass(nameSelected)}`}
           onClick={(e) => ctx.select(rk, -1, e)}
         >
-          {expandable ? (
-            <button
-              type="button"
-              className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
-              aria-expanded={unfolded}
-              title={t(unfolded ? 'common.button.collapse.label' : 'common.button.expand.label')}
-              onClick={() => toggleElement(el.id)}
-            >
-              <Chevron className="size-3.5 shrink-0 text-muted-foreground" />
-              {name}
-            </button>
-          ) : (
-            <span className="flex min-w-0 flex-1 items-center gap-1.5">
-              {isUncategorized ? null : <span className="w-3.5 shrink-0" />}
-              {name}
-            </span>
-          )}
+          {/* the name is a selection target only; just the chevron (or ArrowRight/
+              ArrowLeft on the highlighted name cell) folds the breakdown, so a click
+              meant to highlight the row never springs its children open */}
+          <span className="flex min-w-0 flex-1 items-center gap-1.5">
+            {expandable ? (
+              <button
+                type="button"
+                className="flex shrink-0 items-center"
+                aria-expanded={unfolded}
+                title={t(unfolded ? 'common.button.collapse.label' : 'common.button.expand.label')}
+                onClick={() => toggleElement(el.id)}
+              >
+                <Chevron className="size-3.5 shrink-0 text-muted-foreground" />
+              </button>
+            ) : isUncategorized ? null : (
+              <span className="w-3.5 shrink-0" />
+            )}
+            {name}
+          </span>
         </div>
         {ctx.visibleMonths.map((m, i) => {
           const idx = ctx.monthIndex(m)
@@ -474,10 +490,15 @@ const ElementRow = memo(function ElementRow({ row, ctx }: { row: PlanRow; ctx: G
           const plannedText = cell && cell.planned !== '' ? moneyFormat(cell.planned, currency, { showCurrency: false, useNativePrecision: false }) : '—'
           const actualText = renderActual(cell?.actual, m, ctx.cur, currency)
           const selected = ctx.selection?.rowKey === rk && ctx.selection.col === i
+          const fillSource = ctx.fill.active?.rowKey === rk && ctx.fill.active.startCol === i
           const filled = ctx.fill.active?.rowKey === rk && i > ctx.fill.active.startCol && i <= ctx.fill.active.targetCol
           // an unset cell still shows (and edits as) 0, so it is draggable too —
-          // gating on a set limit would hide the handle on every 0.00 cell
-          const showFillHandle = selected && editable && !!cell && !ctx.isCompact && ctx.visibleMonths.length > 1
+          // gating on a set limit would hide the handle on every 0.00 cell. The
+          // in-flight drag's source keeps its handle mounted even after the pointer
+          // has left the cell: the handle holds the pointer capture, and unmounting
+          // it would drop the pointerup that commits the fill.
+          const showFillHandle =
+            (selected || hoverCol === i || fillSource) && editable && !!cell && !ctx.isCompact && ctx.visibleMonths.length > 1
           return (
             <div
               key={m}
@@ -490,6 +511,8 @@ const ElementRow = memo(function ElementRow({ row, ctx }: { row: PlanRow; ctx: G
               data-testid={`plan-cell-${el.id}:${i}`}
               className={`relative flex flex-col items-end justify-center px-2 py-1${editable ? ' cursor-pointer' : ''} ${selectedClass(selected)}${filled ? ' fill-covered bg-ring/15' : ''}`}
               onClick={(e) => ctx.select(rk, i, e)}
+              onMouseEnter={() => setHoverCol(i)}
+              onMouseLeave={() => setHoverCol((c) => (c === i ? null : c))}
             >
               <span
                 data-testid="cell-actual"
@@ -687,29 +710,42 @@ function FolderRows({
   const visibleRows = collapsed ? [] : visibleSectionRows(section.rows, folded, hideEmpty, revealed)
   const hiddenCount = !folded && hideEmpty && !revealed ? section.rows.filter((r) => r.hidden).length : 0
   const Chevron = folded ? ChevronRight : ChevronDown
+  const rk = folderRowKey(section.folder.id)
+  const selected = ctx.selection?.rowKey === rk
   return (
     <div className="mb-1 rounded-md border p-1.5" data-testid={`plan-folder-${section.folder.id}`}>
       {/* the whole header row is the fold target, not just the name — its own controls
           (the drag grip, the hidden-rows "Show", the actions menu and its portalled
           items, whose clicks re-dispatch through this tree) keep their action and
-          don't fold */}
+          don't fold. A fold click also selects the header, so the arrow keys pick up
+          from here (ArrowLeft/ArrowRight fold/unfold, Up/Down walk the rows). */}
       <div
+        role="row"
         className="flex cursor-pointer flex-wrap items-center justify-between gap-x-2 pb-1"
         onClick={(e) => {
           if ((e.target as HTMLElement).closest(CLICK_ESCAPE_SELECTOR)) {
             return
           }
+          ctx.select(rk, -1, e)
           onToggleFold(section.folder.id)
         }}
       >
-        <span className="flex min-w-0 items-center gap-1">
+        <span
+          role="gridcell"
+          id={cellDomId(rk, -1)}
+          aria-selected={selected}
+          className={`flex min-w-0 items-center gap-1${selectedClass(selected)}`}
+        >
           {ctx.editMode ? <PlanFolderGrip name={section.folder.name} /> : null}
           <button
             type="button"
             className="flex min-w-0 items-center gap-1.5 truncate px-1.5 text-sm font-medium"
             aria-expanded={!folded}
             title={t(folded ? 'common.button.expand.label' : 'common.button.collapse.label')}
-            onClick={() => onToggleFold(section.folder.id)}
+            onClick={(e) => {
+              ctx.select(rk, -1, e)
+              onToggleFold(section.folder.id)
+            }}
           >
             <Chevron className="size-3.5 shrink-0 text-muted-foreground" />
             <span className="truncate">{section.folder.name}</span>
@@ -885,36 +921,36 @@ function PlanBalanceRow({
 }
 
 
-// Same flattening the renderer walks (folders -> loose, income then expense, then
-// archived), so Up/Down can never reach a row that isn't on screen. Only root rows —
-// the ones a limit can be set on — are in the order: an expanded envelope's children
-// are read-only breakdown lines and are stepped over. The uncategorized expense
-// figure is excluded too: it renders as a totals line, not a selectable row.
-interface FlatRow {
-  rowKey: string
-  el: PlanElementDto
-}
+// Same flattening the renderer walks (folders -> loose, income then neutral folders
+// then expense, then archived), so Up/Down can never reach a row that isn't on
+// screen. A folder contributes its header (a selectable row of its own, so it can be
+// folded/unfolded by keyboard) followed by its visible members. Only root element
+// rows — the ones a limit can be set on — are in the order: an expanded envelope's
+// children are read-only breakdown lines and are stepped over. The uncategorized
+// expense figure is excluded too: it renders as a totals line, not a selectable row.
+type FlatRow = { kind: 'element'; rowKey: string; el: PlanElementDto } | { kind: 'folder'; rowKey: string; folderId: Id }
 
 function buildFlatRows(rows: PlanRows, hideEmpty: boolean, revealedSections: Set<string>, folded: (key: string) => boolean): FlatRow[] {
   const flatRows: FlatRow[] = []
   const pushRow = (r: PlanRow) => {
-    flatRows.push({ rowKey: rowKey(r), el: r.element })
+    flatRows.push({ kind: 'element', rowKey: rowKey(r), el: r.element })
+  }
+  const pushFolder = (f: PlanFolderSection) => {
+    flatRows.push({ kind: 'folder', rowKey: folderRowKey(f.folder.id), folderId: f.folder.id })
+    visibleSectionRows(f.rows, folded(f.folder.id), hideEmpty, revealedSections.has(f.folder.id)).forEach(pushRow)
   }
   const incomeFolded = folded('income')
   if (!incomeFolded) {
-    for (const f of rows.income.folders) {
-      visibleSectionRows(f.rows, folded(f.folder.id), hideEmpty, revealedSections.has(f.folder.id)).forEach(pushRow)
-    }
+    rows.income.folders.forEach(pushFolder)
     visibleSectionRows(rows.income.loose, incomeFolded, hideEmpty, revealedSections.has('income')).forEach(pushRow)
     if (rows.income.uncategorized) {
       pushRow(rows.income.uncategorized)
     }
   }
+  rows.neutral.forEach(pushFolder)
   const expenseFolded = folded('expense')
   if (!expenseFolded) {
-    for (const f of rows.expense.folders) {
-      visibleSectionRows(f.rows, folded(f.folder.id), hideEmpty, revealedSections.has(f.folder.id)).forEach(pushRow)
-    }
+    rows.expense.folders.forEach(pushFolder)
     visibleSectionRows(rows.expense.loose, expenseFolded, hideEmpty, revealedSections.has('expense')).forEach(pushRow)
   }
   if (rows.archived.length > 0 && !folded('archived')) {
@@ -1056,6 +1092,7 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
   const togglePlanFold = useBudgetPeriodStore((s) => s.togglePlanFold)
   const folded = useCallback((key: string): boolean => !!planFolds[key], [planFolds])
   const toggleElement = useBudgetPeriodStore((s) => s.toggleElement)
+  const unfoldedElements = useBudgetPeriodStore((s) => s.unfoldedElements)
   const [selection, setSelection] = useState<PlanSelection | null>(null)
   const [fillDrag, setFillDrag] = useState<FillDrag | null>(null)
 
@@ -1067,7 +1104,7 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
     if (!selection || !scroller) {
       return
     }
-    const cell = scroller.querySelector<HTMLElement>(`#${CSS.escape(cellDomId(selection.rowKey, selection.col))}`)
+    const cell = scroller.querySelector<HTMLElement>(`#${CSS.escape(selectionDomId(selection))}`)
     if (!cell) {
       return
     }
@@ -1196,7 +1233,10 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
       fillCells.mutate({ budgetId: budget.meta.id, elementId: fillDrag.elementId, amount: fillDrag.amount, targets })
     }
     setFillDrag(null)
-  }, [fillDrag, visibleMonths, monthIndex, fillCells, budget.meta.id])
+    // the drag may have started from a merely hovered cell: the cell whose value was
+    // copied becomes the selection, so the keyboard picks up from where the mouse left
+    select(fillDrag.rowKey, fillDrag.startCol)
+  }, [fillDrag, visibleMonths, monthIndex, fillCells, budget.meta.id, select])
 
   const fillCancel = useCallback(() => setFillDrag(null), [])
 
@@ -1438,7 +1478,7 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
   // the matching update endpoint: budget role for an envelope (owner|admin|user),
   // row ownership for a category or tag — update-category/update-tag answer anyone
   // but the owner with NotFound, so a shared row must not offer the dialog at all.
-  function openElementEditor(entry: FlatRow) {
+  function openElementEditor(entry: Extract<FlatRow, { kind: 'element' }>) {
     const target = entry.el
     if (target.id === UNCATEGORIZED_ID) {
       return
@@ -1470,6 +1510,10 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
   }
 
   function handleEnter(entry: FlatRow, col: number) {
+    if (entry.kind === 'folder') {
+      togglePlanFold(entry.folderId)
+      return
+    }
     if (col === -1) {
       openElementEditor(entry)
       return
@@ -1531,6 +1575,52 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
       return
     }
     const idx = flatRows.findIndex((r) => r.rowKey === selection.rowKey)
+    const entry = flatRows[idx]
+    // Left/Right on a highlighted folder header fold/unfold it and never move the
+    // selection or page the window — a header has no month cells to walk. Enter and
+    // Space toggle it too (Enter has no edit action on a folder outside its menu).
+    if (entry.kind === 'folder') {
+      const isFolded = folded(entry.folderId)
+      switch (e.key) {
+        case 'ArrowUp':
+          e.preventDefault()
+          if (idx > 0) {
+            select(flatRows[idx - 1].rowKey, selection.col)
+          }
+          break
+        case 'ArrowDown':
+          e.preventDefault()
+          if (idx < flatRows.length - 1) {
+            select(flatRows[idx + 1].rowKey, selection.col)
+          }
+          break
+        case 'ArrowLeft':
+          e.preventDefault()
+          if (!isFolded) {
+            togglePlanFold(entry.folderId)
+          }
+          break
+        case 'ArrowRight':
+          e.preventDefault()
+          if (isFolded) {
+            togglePlanFold(entry.folderId)
+          }
+          break
+        case 'Enter':
+        case ' ':
+          e.preventDefault()
+          togglePlanFold(entry.folderId)
+          break
+        default:
+          break
+      }
+      return
+    }
+    // On a highlighted name cell of a row with children, Left/Right fold/unfold the
+    // breakdown first: ArrowRight expands a collapsed row (and only then walks into
+    // the months), ArrowLeft collapses an expanded one (and only then pages the window).
+    const expandable = entry.el.children.length > 0
+    const unfolded = !!unfoldedElements[entry.el.id]
     switch (e.key) {
       case 'ArrowUp':
         e.preventDefault()
@@ -1547,6 +1637,10 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
       case 'ArrowLeft':
         e.preventDefault()
         if (selection.col === -1) {
+          if (expandable && unfolded) {
+            toggleElement(entry.el.id)
+            break
+          }
           // -1 is the leftmost reachable column, so ArrowLeft here shifts the window
           // instead of going nowhere — keeps the name cell reachable while the window
           // can still be paged from it. Clamped at the budget start, same as the prev
@@ -1564,6 +1658,10 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
       case 'ArrowRight':
         e.preventDefault()
         if (selection.col === -1) {
+          if (expandable && !unfolded) {
+            toggleElement(entry.el.id)
+            break
+          }
           select(selection.rowKey, 0)
         } else if (selection.col >= visible - 1) {
           setPlanFirstMonth(addMonths(firstMonth, 1))
@@ -1574,15 +1672,14 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
         break
       case 'Enter':
         e.preventDefault()
-        handleEnter(flatRows[idx], selection.col)
+        handleEnter(entry, selection.col)
         break
       case ' ':
         // Space on the name cell folds/unfolds the element's children (Enter is the
         // edit shortcut); preventDefault so the scroller does not page down.
         if (selection.col === -1) {
           e.preventDefault()
-          const entry = flatRows[idx]
-          if (entry.el.children.length > 0) {
+          if (expandable) {
             toggleElement(entry.el.id)
           }
         }
@@ -1644,7 +1741,7 @@ export function PlanSheet({ budget, currencies, userId, editMode }: PlanSheetPro
         role="grid"
         tabIndex={0}
         onKeyDown={handleKeyDown}
-        aria-activedescendant={selection ? cellDomId(selection.rowKey, selection.col) : undefined}
+        aria-activedescendant={selection ? selectionDomId(selection) : undefined}
         className="flex min-h-0 flex-1 flex-col overflow-y-auto"
         data-testid="plan-sheet"
       >


### PR DESCRIPTION
## Summary

- **Envelope name click selects only** — just the chevron button toggles the breakdown. On a highlighted name cell of a row with children, `→` unfolds a collapsed row (else moves to the first month, as before) and `←` folds an unfolded one (else pages the window back, as before).
- **Folder headers are selectable rows.** A header click still folds/unfolds and now also selects the folder. On a selected folder `→` unfolds, `←` folds (no-ops otherwise — no window paging), `Enter`/`Space` toggle; `↑`/`↓` walk headers and rows in visual order and keep the column.
- **Fill handle on hover** — the corner dot also renders on the editable month cell under the mouse (whatever is selected), so a value can be dragged right without a selecting click first. The drag source keeps its handle mounted while the drag is in flight and becomes the selection on release.

Spec: `docs/superpowers/specs/2026-08-16-plan-keyboard-fold-hover-fill-design.md`.

## Test plan

- [x] `PlanSheet.test.tsx`: 4 new tests (name click / chevron; envelope arrow fold rules; folder selection + fold keys + column preservation; hover handle + drag-source survival + source selection); 6 existing tests updated for the new semantics
- [x] `pnpm test` — 134 files / 1072 tests pass; `pnpm lint` clean
- [x] Verified live in the browser against the demo DB (keyboard fold/unfold on envelopes and folders, hover dot, drag from a hovered cell selecting the source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)