### PR TITLE
fix: post a future recurring template as today from the account list

### DIFF
--- a/web/src/features/recurring/postPayload.test.ts
+++ b/web/src/features/recurring/postPayload.test.ts
@@ -30,6 +30,28 @@ it('omits labelIds so the server inherits the template\'s labels', () => {
   expect('labelIds' in recurringPostPayload(template({ type: 'transfer', accountRecipientId: 'a2' }), accounts, exchangeFn)).toBe(false)
 })
 
+it('posts a future-dated template as now instead of its scheduled date', () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2026, 7, 20, 14, 30, 45))
+  try {
+    const payload = recurringPostPayload(template({ nextPaymentAt: '2026-09-01 00:00:00' }), accounts, exchangeFn)
+    expect(payload.date).toBe('2026-08-20 14:30:45')
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+it('keeps the scheduled date when the template is due today', () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2026, 7, 20, 14, 30, 45))
+  try {
+    const payload = recurringPostPayload(template({ nextPaymentAt: '2026-08-20 00:00:00' }), accounts, exchangeFn)
+    expect(payload.date).toBe('2026-08-20 00:00:00')
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
 it('mints a fresh transaction id rather than reusing the template id', () => {
   const first = recurringPostPayload(template(), accounts, exchangeFn)
   const second = recurringPostPayload(template(), accounts, exchangeFn)

--- a/web/src/features/recurring/postPayload.ts
+++ b/web/src/features/recurring/postPayload.ts
@@ -1,6 +1,7 @@
 import { v7 as uuidv7 } from 'uuid'
 import type { AccountDto } from '@/api/dto/account'
 import type { PostRecurringPayload, RecurringDto } from '@/api/dto/recurring'
+import { formatDateTime, isFuture } from '@/lib/datetime'
 import { normalize } from '@/lib/decimal'
 
 /**
@@ -41,6 +42,8 @@ export function recurringPostPayload(
     // with no chip row to edit, so it asks the server to inherit the template's
     // labels rather than echoing a possibly-stale cached copy of them
     description: recurring.description || '',
-    date: recurring.nextPaymentAt,
+    // posting ahead of schedule means "pay it now": the money moves today, so a
+    // future scheduled date is clamped to the present rather than written as-is
+    date: isFuture(recurring.nextPaymentAt) ? formatDateTime(new Date()) : recurring.nextPaymentAt,
   }
 }


### PR DESCRIPTION
## Summary
- Posting a scheduled (recurring) transaction from the account page's transaction list used the template's `nextPaymentAt` as the transaction date, so posting a not-yet-due template created a future-dated transaction.
- `recurringPostPayload` now clamps: if the scheduled date is after today (existing `isFuture` day-boundary helper), the transaction posts with the current date/time; due-today and overdue templates keep their scheduled date.
- Frontend-only: the backend's `PostRecurringTransaction` advances the template via `rt.Advance(clock.Now())`, independent of the payload date, so schedule progression is unchanged. The settings-page Post flow (through the transaction dialog, where the date is editable) is untouched.

## Test plan
- [x] New tests in `postPayload.test.ts` (fake timers): future template posts as now; due-today template keeps its scheduled date
- [x] `pnpm vitest run` — 1082/1083 passing; the one failure (`transaction.test.ts` Blob instanceof) is pre-existing and fails on a clean tree too
- [x] `pnpm lint` — clean apart from pre-existing warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)