### PR TITLE
Manual regression test plan + fixes for the findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,6 +354,16 @@ Tests live alongside the Go code:
   `UPDATE_GOLDEN=1 go test ./internal/test/mcpparity/`, then INSPECT the diff — same rule
   as `apiparity`.
 
+### Manual regression test plan
+
+`docs/regression-test-plan.md` is the canonical manual regression checklist
+(all modules, mobile/tablet/desktop viewports, multi-user sharing scenarios).
+**Any change to user-observable behavior MUST update the affected checklist
+items in the same PR** — add cases for new features, edit changed flows,
+delete removed ones, and add an item for any regression that escaped to
+production. Keep items phrased as verifiable outcomes and keep the 📱
+(mobile/tablet) markers accurate.
+
 Coverage gate: `make go-test` enforces a cross-package minimum (`GO_COVER_MIN`,
 default 80). CI surfaces the coverage % in the Actions job summary plus an HTML
 artifact (`.github/workflows/go-tests.yml`).

--- a/docs/regression-test-plan.md
+++ b/docs/regression-test-plan.md
@@ -1,0 +1,352 @@
+# Econumo — Manual Regression Test Plan
+
+This is the canonical manual regression checklist for the Econumo app. Run it
+before every release (or any risky change) against a build of the release
+candidate. Automated suites (`make test`, apiparity/enginecompare goldens)
+already pin the API contract — this plan focuses on what they cannot see:
+real-browser UI behavior, responsive layouts, multi-user sharing flows, and
+end-to-end journeys.
+
+> **Maintenance rule:** whenever user-observable behavior changes (a new
+> feature, a changed flow, a removed control), update the affected checklist
+> items in the same PR. See "Maintaining this plan" at the bottom.
+
+---
+
+## 1. Environment setup
+
+1. Build the release candidate: `cd web && pnpm build`, then
+   `go build -o ./econumo ./cmd/econumo` (the SPA embeds into the binary).
+2. Run against a **fresh, empty** SQLite database so onboarding and
+   registration are exercised:
+
+   ```bash
+   DATABASE_URL="sqlite:///tmp/econumo-regression.sqlite" \
+   PORT=8181 \
+   ECONUMO_ALLOW_REGISTRATION=true \
+   ECONUMO_ANALYTICS=false \
+   ./econumo serve
+   ```
+
+3. Open `http://localhost:8181` — the embedded SPA and API share one origin.
+4. Test data conventions used below — create these three users (via the
+   registration UI, which doubles as the registration test):
+   - **User A** ("Alice") — primary user, owns most data.
+   - **User B** ("Bob") — sharing partner: connected to A, gets shared
+     accounts/budgets in various roles.
+   - **User C** ("Carol") — isolation control: never connected; used to verify
+     that A/B's data never leaks to an unrelated user.
+5. Optionally verify CLI user creation too:
+   `./econumo user:create "Carol" carol@example.test secret123`.
+
+### Viewport matrix
+
+Every suite below gets a full pass on **Desktop**; the items marked 📱 get an
+extra pass on Mobile and Tablet. When time is short, prioritize: dialogs
+(drawer vs centered dialog), row action menus (bottom sheet vs dropdown),
+navigation (single-pane vs sidebar).
+
+| Viewport | Size | What changes |
+|---|---|---|
+| Desktop | 1280×800+ | Sidebar + workspace side by side; dropdown menus; centered dialogs; collapse rail |
+| Tablet | 768×1024 | Compact shell (single pane, `<1024px`): sidebar only on `/`, page headers with back buttons, bottom-sheet row actions; dialogs still centered (`≥640px`) |
+| Mobile | 375×812 | Same compact shell **plus** bottom-sheet drawers instead of dialogs (`<640px`), FAB on account page, safe-area insets |
+
+---
+
+## 2. Authentication & registration
+
+- [ ] 📱 Register a new user: name/email/password/confirm; inline validation
+      (short password, mismatched confirm, bad email); redirected to login.
+- [ ] Register with an email that already exists → clear field error, no
+      account created.
+- [ ] Login with correct credentials → lands on `/` (onboarding for a fresh
+      user); wrong password → error dialog, no session created.
+- [ ] "Remember email" checkbox pre-fills the email on next visit.
+- [ ] Forgot password: send code → email arrives (console transport prints to
+      server stdout in dev) → enter code + new password → old password rejected,
+      new one works; all other sessions of the user are revoked.
+- [ ] Recovery with a wrong/expired code → clear error, password unchanged.
+- [ ] Logout (Settings → Profile → Log out, with confirm) → back at login; the
+      session disappears from the Sessions list (check from another session).
+- [ ] Expired/invalid token: clear the token (or revoke the session elsewhere)
+      → next API call redirects to `/login?reason=expired` with the
+      session-expired notice.
+- [ ] With `ECONUMO_ALLOW_REGISTRATION=false`: Sign-up tab is disabled on the
+      login screen and registering via API returns an error.
+- [ ] With `ECONUMO_EMAIL_VERIFICATION=true` (separate boot): fresh
+      registration → first login is blocked, code email is sent, verification
+      dialog accepts the code, resend has a cooldown, then login proceeds.
+- [ ] Language badge/selector on the login page switches the auth UI language
+      and persists.
+
+## 3. Onboarding (fresh user)
+
+- [ ] 📱 A fresh user lands on onboarding; steps show completion checkmarks as
+      they are done (account created, transactions, classifications, avatar,
+      connections, budget).
+- [ ] Inline actions work from the onboarding page: add account, import CSV,
+      pick avatar.
+- [ ] "Complete onboarding" navigates to `/budget`; the sidebar onboarding link
+      disappears; `/` now renders the budget.
+
+## 4. Accounts & folders
+
+- [ ] 📱 Create account from the sidebar and from Settings → Accounts: name,
+      starting balance (calculator input accepts a formula, e.g. `100+23.5`),
+      currency, icon. Balance shows correctly in the sidebar and account page.
+- [ ] Starting balance creates a "correction"-style initial transaction dated
+      now; account page shows it.
+- [ ] Edit account: rename, change icon; balance edit creates a correction to
+      match the new balance.
+- [ ] Create a second currency account (e.g. EUR) — requires the currency to be
+      enabled in Settings → Currencies first.
+- [ ] Folders: create, rename, collapse/expand, hide/show (hidden folder
+      disappears from sidebar but its accounts stay reachable via settings),
+      delete (only sensible when empty / accounts are moved), reorder folders.
+- [ ] Drag-and-drop an account within a folder and across folders (desktop);
+      order persists after reload.
+- [ ] Delete an account with transactions → confirm dialog; account disappears;
+      its balance is zeroed by an automatic "Balance adjustment (account
+      deleted)" correction; a budget that included it keeps the history
+      (spent/budgeted-before figures unchanged).
+- [ ] Account page 📱: transaction list groups by day, "today" anchor,
+      future-dated (not-posted recurring) entries render above with markers;
+      search filters the list; virtualized scroll stays smooth with 100+ rows.
+- [ ] Mobile: FAB adds a transaction; row tap opens the preview bottom sheet.
+
+## 5. Transactions
+
+- [ ] 📱 Create expense / income / transfer from the account page and via the
+      global add button: date picker, amount (formula), category & payee
+      selects with **create-on-type** inline creation, tags & labels chips,
+      description.
+- [ ] Cross-currency transfer (USD account → EUR account) asks for both
+      amounts; both accounts' balances update by their respective amounts.
+- [ ] Same-currency transfer: single amount; swap from/to button works.
+- [ ] Edit a transaction (amount, category, date, account) → balances and
+      budget figures update everywhere (sidebar, account header, budget table).
+- [ ] Delete from row menu and from preview dialog → confirm → balance updates.
+- [ ] Preview dialog: read-only cards; edit/delete hidden when the caller lacks
+      write access (see sharing suite); "make recurring" pre-fills the
+      recurring dialog.
+- [ ] Future-dated transaction shows above the "today" separator and does not
+      count toward "balance as of end of today".
+- [ ] **CSV import** 📱: pick a file, map columns (single amount and
+      inflow/outflow dual mode, date, category, payee, description, tags,
+      labels with separator), constant-value fields; result dialog shows
+      imported/failed counts and per-row errors; imported rows appear with
+      correct signs and classifications.
+- [ ] Import with a broken row (bad date/amount) → partial result, failed rows
+      detailed, good rows imported.
+- [ ] **CSV export**: multi-select accounts, select-all/deselect-all; exported
+      file contains the expected rows/columns and respects the account choice.
+
+## 6. Recurring transactions
+
+- [ ] 📱 Create a recurring rule (from a transaction's "make recurring" and
+      from Settings → Recurring): type, amount, schedule, accounts, category.
+- [ ] Due occurrence appears on the account page as "not posted"; Post creates
+      the real transaction (idempotent — no double post on double click) and
+      advances the schedule; Skip advances without posting.
+- [ ] Month-end clamping: a rule scheduled for the 31st posts on Feb 28/29 and
+      returns to the 31st in March.
+- [ ] Edit and delete a rule; delete asks for confirmation; posted transactions
+      survive rule deletion.
+- [ ] Recurring settings page groups rules by account; actions are gated by
+      write permission on shared accounts.
+
+## 7. Classifications (categories, tags, labels, payees)
+
+For **each** of categories / tags / payees (and labels inside the tags page):
+
+- [ ] 📱 Create, rename, change icon (and type/kind where applicable:
+      expense/income category tabs, tag-vs-label kind toggle — kind locked
+      after creation).
+- [ ] Archive → item leaves active lists and pickers but history keeps it;
+      unarchive restores; "active only" switch reveals archived entries.
+- [ ] Delete an unused item; deleting one in use warns / behaves per rules.
+- [ ] Merge two items (`MergeDialog`) → transactions of the source move to the
+      target, source disappears; category merge warns when the source is bound
+      to a budget envelope.
+- [ ] Manual sort dialog + drag reorder persists order across reload and is
+      reflected in transaction-dialog pickers.
+- [ ] Search (inline on desktop, search dialog on compact) and empty states.
+- [ ] Creating from within the transaction dialog (create-on-type) lands the
+      item in the settings list too.
+
+## 8. Currencies
+
+- [ ] "My currencies" vs "Global currencies" tabs; enable/disable one currency;
+      bulk enable-all/disable-all.
+- [ ] Base currency and profile currency rows are locked with a reason.
+- [ ] Create a custom currency (name, code, symbol, fraction digits, rate);
+      it becomes usable for accounts; edit it; delete it (soft delete —
+      accounts/transactions in it keep resolving symbol and rate).
+- [ ] Rates caption shows the rate and the SPA converts non-base balances in
+      totals (sidebar total, budget expense widget note).
+- [ ] Change profile default currency (Settings → Profile) → totals and budget
+      default currency chips update.
+
+## 9. Budgets — table & plan
+
+- [ ] 📱 Create a budget: name, currency, ≥1 owned account required; appears in
+      the sidebar; becomes default when first/chosen.
+- [ ] Budget table: budgeted / spent / available columns; expanding an element
+      shows details; totals row; uncategorized and labels sections appear with
+      info notes when relevant.
+- [ ] Element visibility rule: a category/tag/envelope with **either** spending
+      or a limit (incl. carried over) is visible; with neither it is not.
+- [ ] Set a limit via the available cell / set-limit dialog; formula input;
+      limit shows immediately and carries into the next period per rules.
+- [ ] Spent cell drilldown opens the transactions dialog (filtered list,
+      preview, delete works and refreshes figures).
+- [ ] Period strip: navigate previous/next months; figures change; periods
+      before the budget start are not offered; clamped at the end month for
+      ended budgets.
+- [ ] Currency filter chips (multi-currency data) filter rows/totals.
+- [ ] **Edit structure** mode 📱: create folder, drag elements between folders,
+      per-element menu (change currency, move to folder, edit envelope, delete
+      envelope), delete folder; leaving the mode persists the layout.
+- [ ] Envelopes: create (name, currency, categories multi-select, icon);
+      transactions of member categories aggregate under the envelope; edit
+      membership; delete envelope returns categories to top level.
+- [ ] Tag on a transaction: spending counts toward the **tag** element, not the
+      category (tagged-spend accounting rule).
+- [ ] **Plan sheet** 📱: spreadsheet grid renders months; inline edit of a
+      planned amount; keyboard cell navigation (arrows), Excel-style
+      fill-right by drag handle (desktop) and Shift+Arrow; month window
+      scrolling; hide-empty-rows toggle; transfers/balance totals rows show
+      tooltips.
+- [ ] Budget with accounts in two currencies: per-currency balances section is
+      correct; expense widget shows the conversion note.
+
+## 10. Budget lifecycle & list
+
+- [ ] Budgets list (Settings → Budgets): set default, open, edit (name +
+      accounts replace-set), delete with confirm.
+- [ ] **Accounts membership**: adding/removing accounts in edit; an account
+      with transactions inside the budget window since the start of the
+      current month cannot be removed (clear error); hidden-accounts note and
+      included counter are correct (never "N of M" with N>M).
+- [ ] **Duplicate** (clone): deep copy with/without plans from a chosen start
+      month; copy starts unarchived/open-ended; structure and sharing carried.
+- [ ] **Complete**: sets end month; optionally continues with a copy (+ plans,
+      new name). Ended budget: period strip clamps at end month, set-limit
+      refuses later periods.
+- [ ] **Archive**: archived budget is hidden from the main list (archived
+      section toggle reveals it) and is read-only — every write is refused
+      with the "budget archived" error except unarchive/delete/sharing-exit
+      actions; unarchive restores writability.
+- [ ] Reset budget (if surfaced in UI) clears plans after confirm.
+
+## 11. Sharing — connections, accounts, budgets (multi-user)
+
+Run with Users A and B side by side (two browser profiles/windows), verifying
+User C sees none of it.
+
+**Connections**
+- [ ] 📱 A generates an invite code; B accepts it via the dialog → both see the
+      connection with avatars; wrong/expired code → clear error; rate limiting
+      after repeated bad codes (429 toast).
+- [ ] Delete the connection (confirm) → shared grants are revoked on both
+      sides.
+
+**Account sharing**
+- [ ] A shares an account with B (`guest`, then upgrade to `user`, `admin`):
+      B gets a sharing-request badge; the requests dialog lists the invite
+      with folder selection; Accept places the account in the chosen folder.
+- [ ] Decline works (with confirm) and removes the pending invite.
+- [ ] Role behavior: `guest` = read-only (no add/edit/delete transaction
+      controls anywhere — row menu, preview, FAB); `user` can write
+      transactions; `admin` can also edit the account. Verify on desktop
+      dropdowns AND mobile bottom sheets.
+- [ ] Shared account shows the owner's avatar/mark in B's sidebar; A sees B's
+      avatar on the account's shared stack.
+- [ ] B sees A's categories/payees/tags via the shared account and can use
+      them on transactions in that account; B cannot edit A's classifications.
+- [ ] A revokes access → the account disappears from B's sidebar immediately
+      (or on next sync); B's own data untouched.
+- [ ] Owner deletes a shared account → it disappears for B too.
+
+**Budget sharing**
+- [ ] A shares a budget with B (reader and admin roles): B accepts via the
+      requests dialog; accepted budget becomes B's default; B sees elements,
+      figures, and A's shared accounts inside the budget.
+- [ ] Budget roles: reader cannot change limits/structure (entry points
+      disabled, not just failing); admin can set limits and edit structure.
+- [ ] A participant leaving (decline after accept / revoke) removes their
+      accounts from the budget with them.
+- [ ] Archived shared budget: B can still leave/decline but not write.
+
+## 12. Profile & security settings
+
+- [ ] 📱 Avatar picker: icon + color; persists; shows in sidebar and shared
+      stacks on the partner's side.
+- [ ] Name inline edit with validation (length limits).
+- [ ] Default currency picker and language dialog persist (language also
+      server-side — a relogin/other device keeps it).
+- [ ] **Change password**: wrong old password rejected; success revokes all
+      *other* sessions (verify: second browser session is logged out, current
+      one stays).
+- [ ] **Change email**: request (new email + password) → code sent to the new
+      address → confirm; resend with cooldown; wrong code rejected; login works
+      with the new email only.
+- [ ] **Sessions** 📱: list shows device descriptions, current badge, relative
+      last-active; revoke one (other) session logs that device out; revoke-all-
+      others keeps only the current; revoking the current session logs out.
+- [ ] **Personal access tokens** 📱: create with expiry presets + custom date;
+      token revealed exactly once with copy button; API call with the PAT
+      works (e.g. `GET /api/v1/user/get-user-data`); revoked PAT stops working;
+      list shows last-used/expiry.
+
+## 13. Cross-cutting & platform
+
+- [ ] i18n: switch to a non-English language — spot-check every page for
+      untranslated keys/overflowing labels; server-rendered errors (e.g. bad
+      login) arrive translated; switch back.
+- [ ] Sync button: spins during refetch; failure (kill the server briefly)
+      turns it amber with a tooltip; recovery clears it. App restores from the
+      persisted cache on reload without a boot-loader flash.
+- [ ] Update notices: with a newer release available, the dismissible sidebar
+      notice and the settings "update available" row appear (can be simulated
+      by pointing `ECONUMO_VERSION` at an old value).
+- [ ] Readonly/trial gating (cloud only, `ECONUMO_TRIAL` set): expired user
+      gets 402 toasts on writes, subscription banner shows; security actions
+      (logout, password, sessions) still work.
+- [ ] 404 page renders for an unknown route; deep links (e.g. `/settings/
+      profile/sessions`, `/account/<id>`) survive a hard reload.
+- [ ] API docs reachable from settings footer (`/api/doc`).
+- [ ] No console errors during a full pass (keep dev tools open); no PII in
+      server logs (spot-check).
+
+## 14. Responsive-specific sweep 📱
+
+A dedicated pass on Mobile (375×812) and Tablet (768×1024):
+
+- [ ] Navigation: `/` shows the sidebar-as-home; entering any page shows a
+      back-button header; back always returns to the logical origin.
+- [ ] Every dialog used in the suites above renders as a bottom-sheet drawer on
+      mobile (<640px) and a centered dialog on tablet — content scrolls, safe
+      areas respected, keyboard does not cover inputs.
+- [ ] Row actions open bottom sheets (accounts, transactions, classifications,
+      recurring, sessions, tokens, budgets).
+- [ ] Long lists scroll smoothly; sidebar scroll position is remembered when
+      navigating back.
+- [ ] Plan sheet is usable on tablet (fill handle desktop-only is expected).
+- [ ] Toolbar buttons collapse labels to icons without overflow; no horizontal
+      page scrolling anywhere.
+
+---
+
+## Maintaining this plan
+
+- This document lives at `docs/regression-test-plan.md` and is part of the
+  definition of done for behavior changes: **any PR that changes
+  user-observable behavior must update the affected checklist items** (add
+  cases for new features, edit changed flows, delete removed ones).
+- Keep items phrased as verifiable outcomes ("X happens"), not instructions
+  ("click X").
+- Keep the 📱 markers accurate — they drive the mobile/tablet passes.
+- When a regression escapes to production, add a checklist item that would
+  have caught it.

--- a/docs/regression-test-plan.md
+++ b/docs/regression-test-plan.md
@@ -67,12 +67,12 @@ navigation (single-pane vs sidebar).
 
 - [ ] 📱 Register a new user: name/email/password/confirm; inline validation
       (short password, mismatched confirm, bad email); redirected to login.
-      > **Known blocker (until the hidden-`host` validation bug is fixed):**
-      > in a fresh browser with `ALLOW_CUSTOM_API` on, login/registration
-      > silently no-op. Workaround: expand "Connect to a custom server" once
-      > (it seeds the address) and collapse or leave it — then submit works.
-- [ ] Register with an email that already exists → clear field error, no
-      account created.
+      Must work in a fresh browser profile with the custom-server section
+      collapsed (regression guard: the hidden `host` field once blocked every
+      submit on self-hosted instances).
+- [ ] Register with an email that already exists → the failure dialog states
+      the server's reason ("User already exists", localized), no account
+      created.
 - [ ] Login with correct credentials → lands on `/` (onboarding for a fresh
       user); wrong password → error dialog, no session created.
 - [ ] "Remember email" checkbox pre-fills the email on next visit.
@@ -86,7 +86,8 @@ navigation (single-pane vs sidebar).
       → next API call redirects to `/login?reason=expired` with the
       session-expired notice.
 - [ ] With `ECONUMO_ALLOW_REGISTRATION=false`: Sign-up tab is disabled on the
-      login screen and registering via API returns an error.
+      login screen, opening `/register` directly redirects to the login page,
+      and registering via API returns an error.
 - [ ] With `ECONUMO_EMAIL_VERIFICATION=true` (separate boot): fresh
       registration → first login is blocked, code email is sent, verification
       dialog accepts the code, resend has a cooldown, then login proceeds.
@@ -223,9 +224,10 @@ For **each** of categories / tags / payees (and labels inside the tags page):
       limit shows immediately and carries into the next period per rules.
 - [ ] Spent cell drilldown opens the transactions dialog (filtered list,
       preview, delete works and refreshes figures).
-- [ ] Period strip: navigate previous/next months; figures change; periods
-      before the budget start are not offered; clamped at the end month for
-      ended budgets.
+- [ ] Period strip: navigate previous/next months; figures change; months
+      before the budget start or past the end month are not offered (the
+      active month stays visible even if the stored selection is outside);
+      scrolling never extends past the budget's lifetime.
 - [ ] Currency filter chips (multi-currency data) filter rows/totals.
 - [ ] **Edit structure** mode 📱: create folder, drag elements between folders,
       per-element menu (change currency, move to folder, edit envelope, delete
@@ -252,8 +254,9 @@ For **each** of categories / tags / payees (and labels inside the tags page):
       with transactions inside the budget window since the start of the
       current month cannot be removed (clear error); hidden-accounts note and
       included counter are correct (never "N of M" with N>M).
-- [ ] **Duplicate** (clone): deep copy with/without plans from a chosen start
-      month; copy starts unarchived/open-ended; structure and sharing carried.
+- [ ] **Duplicate** (clone): name pre-fills with a localized "(copy)" suffix;
+      deep copy with/without plans from a chosen start month; copy starts
+      unarchived/open-ended; structure and sharing carried.
 - [ ] **Complete**: sets end month; optionally continues with a copy (+ plans,
       new name). Ended budget: period strip clamps at end month, set-limit
       refuses later periods.
@@ -278,7 +281,9 @@ User C sees none of it.
 **Account sharing**
 - [ ] A shares an account with B (`guest`, then upgrade to `user`, `admin`):
       B gets a sharing-request badge; the requests dialog lists the invite
-      with folder selection; Accept places the account in the chosen folder.
+      with folder selection; Accept places the account in the chosen folder
+      and A's categories/payees/tags resolve on B's side immediately (no
+      "Uncategorized" rows, no stale caches).
 - [ ] Decline works (with confirm) and removes the pending invite.
 - [ ] Role behavior: `guest` = read-only (no add/edit/delete transaction
       controls anywhere — row menu, preview, FAB); `user` can write

--- a/docs/regression-test-plan.md
+++ b/docs/regression-test-plan.md
@@ -21,12 +21,21 @@ end-to-end journeys.
    registration are exercised:
 
    ```bash
+   rm -f /tmp/econumo-regression.sqlite
    DATABASE_URL="sqlite:///tmp/econumo-regression.sqlite" \
    PORT=8181 \
    ECONUMO_ALLOW_REGISTRATION=true \
    ECONUMO_ANALYTICS=false \
+   ECONUMO_EMAIL_VERIFICATION=false \
+   ECONUMO_ADMIN_PORT= ECONUMO_ADMIN_TOKEN= ECONUMO_BILLING_URL= ECONUMO_DATA_SALT= \
    ./econumo serve
    ```
+
+   The binary loads the repo `.env` for any variable not set in the shell, so
+   the explicit empty overrides above are required — otherwise a developer
+   `.env` can silently enable the admin listener (port collision at boot),
+   email verification, or a data salt. `rm -f` guarantees the DB is fresh on
+   repeat runs.
 
 3. Open `http://localhost:8181` — the embedded SPA and API share one origin.
 4. Test data conventions used below — create these three users (via the
@@ -58,6 +67,10 @@ navigation (single-pane vs sidebar).
 
 - [ ] 📱 Register a new user: name/email/password/confirm; inline validation
       (short password, mismatched confirm, bad email); redirected to login.
+      > **Known blocker (until the hidden-`host` validation bug is fixed):**
+      > in a fresh browser with `ALLOW_CUSTOM_API` on, login/registration
+      > silently no-op. Workaround: expand "Connect to a custom server" once
+      > (it seeds the address) and collapse or leave it — then submit works.
 - [ ] Register with an email that already exists → clear field error, no
       account created.
 - [ ] Login with correct credentials → lands on `/` (onboarding for a fresh
@@ -99,11 +112,15 @@ navigation (single-pane vs sidebar).
       now; account page shows it.
 - [ ] Edit account: rename, change icon; balance edit creates a correction to
       match the new balance.
-- [ ] Create a second currency account (e.g. EUR) — requires the currency to be
-      enabled in Settings → Currencies first.
+- [ ] Create a second currency account (e.g. EUR). On a fresh self-hosted DB
+      (no OER token) there are no global currencies besides USD — create a
+      custom currency in Settings → Currencies first (name, code, symbol,
+      rate); that is the normal manual path.
 - [ ] Folders: create, rename, collapse/expand, hide/show (hidden folder
       disappears from sidebar but its accounts stay reachable via settings),
-      delete (only sensible when empty / accounts are moved), reorder folders.
+      delete — deleting a folder MOVES its accounts into the general folder
+      (nothing is lost); the general folder itself offers no Delete; reorder
+      folders.
 - [ ] Drag-and-drop an account within a folder and across folders (desktop);
       order persists after reload.
 - [ ] Delete an account with transactions → confirm dialog; account disappears;
@@ -112,7 +129,9 @@ navigation (single-pane vs sidebar).
       (spent/budgeted-before figures unchanged).
 - [ ] Account page 📱: transaction list groups by day, "today" anchor,
       future-dated (not-posted recurring) entries render above with markers;
-      search filters the list; virtualized scroll stays smooth with 100+ rows.
+      search filters the list; virtualized scroll stays smooth with 100+ rows
+      (seed them via CSV import — a generated 100+-row file doubles as the
+      import-at-scale test).
 - [ ] Mobile: FAB adds a transaction; row tap opens the preview bottom sheet.
 
 ## 5. Transactions
@@ -146,11 +165,13 @@ navigation (single-pane vs sidebar).
 
 - [ ] 📱 Create a recurring rule (from a transaction's "make recurring" and
       from Settings → Recurring): type, amount, schedule, accounts, category.
-- [ ] Due occurrence appears on the account page as "not posted"; Post creates
-      the real transaction (idempotent — no double post on double click) and
-      advances the schedule; Skip advances without posting.
-- [ ] Month-end clamping: a rule scheduled for the 31st posts on Feb 28/29 and
-      returns to the 31st in March.
+- [ ] Due occurrence appears on the account page as "not posted". Post from the
+      account-page row preview posts immediately (dated today); Post from
+      Settings → Recurring opens a pre-filled review dialog (scheduled date)
+      that you confirm. Both advance the schedule. Skip (advances without
+      posting) is offered ONLY on the account-page row preview.
+- [ ] Month-end clamping (31st → Feb 28 → Mar 31) is long-horizon — covered by
+      unit tests; in a manual run just note the next-date math looks right.
 - [ ] Edit and delete a rule; delete asks for confirmation; posted transactions
       survive rule deletion.
 - [ ] Recurring settings page groups rules by account; actions are gated by
@@ -161,8 +182,8 @@ navigation (single-pane vs sidebar).
 For **each** of categories / tags / payees (and labels inside the tags page):
 
 - [ ] 📱 Create, rename, change icon (and type/kind where applicable:
-      expense/income category tabs, tag-vs-label kind toggle — kind locked
-      after creation).
+      expense/income category tabs, kind toggle — "Budget tag" is the tag entity,
+      "Reporting tag" is the label entity; kind locked after creation).
 - [ ] Archive → item leaves active lists and pickers but history keeps it;
       unarchive restores; "active only" switch reveals archived entries.
 - [ ] Delete an unused item; deleting one in use warns / behaves per rules.
@@ -178,7 +199,8 @@ For **each** of categories / tags / payees (and labels inside the tags page):
 ## 8. Currencies
 
 - [ ] "My currencies" vs "Global currencies" tabs; enable/disable one currency;
-      bulk enable-all/disable-all.
+      bulk enable-all/disable-all. Only executable when server-side global
+      currencies exist (rates fetched); a fresh DB has just the locked USD.
 - [ ] Base currency and profile currency rows are locked with a reason.
 - [ ] Create a custom currency (name, code, symbol, fraction digits, rate);
       it becomes usable for accounts; edit it; delete it (soft delete —
@@ -208,7 +230,8 @@ For **each** of categories / tags / payees (and labels inside the tags page):
 - [ ] **Edit structure** mode 📱: create folder, drag elements between folders,
       per-element menu (change currency, move to folder, edit envelope, delete
       envelope), delete folder; leaving the mode persists the layout.
-- [ ] Envelopes: create (name, currency, categories multi-select, icon);
+- [ ] Envelopes: create via the "+" button on a folder header in Edit
+      structure mode (name, currency, categories multi-select);
       transactions of member categories aggregate under the envelope; edit
       membership; delete envelope returns categories to top level.
 - [ ] Tag on a transaction: spending counts toward the **tag** element, not the
@@ -308,9 +331,10 @@ User C sees none of it.
 - [ ] Sync button: spins during refetch; failure (kill the server briefly)
       turns it amber with a tooltip; recovery clears it. App restores from the
       persisted cache on reload without a boot-loader flash.
-- [ ] Update notices: with a newer release available, the dismissible sidebar
-      notice and the settings "update available" row appear (can be simulated
-      by pointing `ECONUMO_VERSION` at an old value).
+- [ ] Update notices (environment-dependent — needs `ECONUMO_CHECK_UPDATES`
+      and reachability of econumo.com): with a newer release available, the
+      dismissible sidebar notice and the settings "update available" row
+      appear (simulate by pointing `ECONUMO_VERSION` at an old value).
 - [ ] Readonly/trial gating (cloud only, `ECONUMO_TRIAL` set): expired user
       gets 402 toasts on writes, subscription banner shows; security actions
       (logout, password, sessions) still work.
@@ -326,9 +350,11 @@ A dedicated pass on Mobile (375×812) and Tablet (768×1024):
 
 - [ ] Navigation: `/` shows the sidebar-as-home; entering any page shows a
       back-button header; back always returns to the logical origin.
-- [ ] Every dialog used in the suites above renders as a bottom-sheet drawer on
-      mobile (<640px) and a centered dialog on tablet — content scrolls, safe
-      areas respected, keyboard does not cover inputs.
+- [ ] Every dialog used in the suites above renders as a bottom-sheet drawer
+      (short content: previews, action lists, confirms) or a full-screen sheet
+      (long forms, e.g. Add transaction) on mobile (<640px), and a centered
+      dialog on tablet — content scrolls, safe areas respected, keyboard does
+      not cover inputs.
 - [ ] Row actions open bottom sheets (accounts, transactions, classifications,
       recurring, sessions, tokens, budgets).
 - [ ] Long lists scroll smoothly; sidebar scroll position is remembered when

--- a/internal/connection/invite_usecase.go
+++ b/internal/connection/invite_usecase.go
@@ -76,6 +76,11 @@ func (s *Service) AcceptInvite(ctx context.Context, userID vo.Id, req model.Acce
 	if err := s.tx.WithTx(ctx, func(txCtx context.Context) error {
 		inv, gerr := s.invites.GetByCode(txCtx, code, s.clock.Now())
 		if gerr != nil {
+			// The repo's not-found is an internal entity name; the caller typed
+			// a code that is wrong or expired — tell them that, localized.
+			if _, notFound := errs.AsNotFound(gerr); notFound {
+				return &errs.ValidationError{Msg: "The invitation code is invalid or has expired.", MsgCode: errs.CodeConnectionInviteNotFound}
+			}
 			return gerr
 		}
 		if inv.UserID.Equal(userID) {

--- a/internal/shared/errs/codes.go
+++ b/internal/shared/errs/codes.go
@@ -57,6 +57,7 @@ const (
 	CodeConnectionInvalidCode      = "connection.invalid_code"
 	CodeConnectionInvitingYourself = "connection.inviting_yourself"
 	CodeConnectionDeletingYourself = "connection.deleting_yourself"
+	CodeConnectionInviteNotFound   = "connection.invite_not_found"
 
 	CodePayeeNameLength     = "payee.name_length"
 	CodePayeeAlreadyExists  = "payee.already_exists"
@@ -155,6 +156,7 @@ var AllCodes = []string{
 	CodeConnectionInvalidCode,
 	CodeConnectionInvitingYourself,
 	CodeConnectionDeletingYourself,
+	CodeConnectionInviteNotFound,
 
 	CodePayeeNameLength,
 	CodePayeeAlreadyExists,

--- a/locales/de.json
+++ b/locales/de.json
@@ -853,6 +853,7 @@
       },
       "duplicate_budget_form": {
         "header": "Budget duplizieren",
+        "copy_name": "{name} (Kopie)",
         "copy_plans": "Pläne kopieren",
         "start_this_month": "Ab diesem Monat beginnen"
       },
@@ -1468,7 +1469,8 @@
       "invalid_role_alias": "AccountRole mit dem Alias {alias} existiert nicht",
       "invalid_code": "Der Einladungscode ist ungültig",
       "inviting_yourself": "Sie möchten sich selbst einladen?",
-      "deleting_yourself": "Sie möchten sich selbst entfernen?"
+      "deleting_yourself": "Sie möchten sich selbst entfernen?",
+      "invite_not_found": "Der Einladungscode ist ungültig oder abgelaufen."
     },
     "currency": {
       "already_exists": "Diese Währung existiert bereits",

--- a/locales/en.json
+++ b/locales/en.json
@@ -429,8 +429,8 @@
       "success_title": "Import complete",
       "partial_success_title": "Import completed with errors",
       "error_title": "Import failed",
-      "imported": "{count} transaction(s) imported | {count} transactions imported",
-      "failed": "{count} transaction(s) failed | {count} transactions failed",
+      "imported": "{count} transaction imported | {count} transactions imported",
+      "failed": "{count} transaction failed | {count} transactions failed",
       "errors_detail": "Error details",
       "row": "Row",
       "rows": "Rows",
@@ -853,6 +853,7 @@
       },
       "duplicate_budget_form": {
         "header": "Duplicate budget",
+        "copy_name": "{name} (copy)",
         "copy_plans": "Copy plans",
         "start_this_month": "Start from this month"
       },
@@ -1468,7 +1469,8 @@
       "invalid_role_alias": "AccountRole with alias {alias} not exists",
       "invalid_code": "ConnectionCode is incorrect",
       "inviting_yourself": "Inviting yourself?",
-      "deleting_yourself": "Deleting yourself?"
+      "deleting_yourself": "Deleting yourself?",
+      "invite_not_found": "The invitation code is invalid or has expired."
     },
     "currency": {
       "already_exists": "Currency already exists",

--- a/locales/es.json
+++ b/locales/es.json
@@ -853,6 +853,7 @@
       },
       "duplicate_budget_form": {
         "header": "Duplicar presupuesto",
+        "copy_name": "{name} (copia)",
         "copy_plans": "Copiar planes",
         "start_this_month": "Empezar desde este mes"
       },
@@ -1468,7 +1469,8 @@
       "invalid_role_alias": "No existe ningún rol de acceso a la cuenta con el alias {alias}.",
       "invalid_code": "El código de conexión es incorrecto.",
       "inviting_yourself": "¿Invitarte a ti mismo?",
-      "deleting_yourself": "¿Eliminarte a ti mismo?"
+      "deleting_yourself": "¿Eliminarte a ti mismo?",
+      "invite_not_found": "El código de invitación no es válido o ha caducado."
     },
     "currency": {
       "already_exists": "La moneda ya existe.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -853,6 +853,7 @@
       },
       "duplicate_budget_form": {
         "header": "Dupliquer le budget",
+        "copy_name": "{name} (copie)",
         "copy_plans": "Copier les plans",
         "start_this_month": "Commencer ce mois-ci"
       },
@@ -1468,7 +1469,8 @@
       "invalid_role_alias": "Le rôle d’accès au compte avec l’alias {alias} n’existe pas.",
       "invalid_code": "Le code de connexion est incorrect.",
       "inviting_yourself": "Vous vous invitez vous-même ?",
-      "deleting_yourself": "Vous vous supprimez vous-même ?"
+      "deleting_yourself": "Vous vous supprimez vous-même ?",
+      "invite_not_found": "Le code d'invitation est invalide ou a expiré."
     },
     "currency": {
       "already_exists": "Cette devise existe déjà.",

--- a/locales/it.json
+++ b/locales/it.json
@@ -853,6 +853,7 @@
       },
       "duplicate_budget_form": {
         "header": "Duplica budget",
+        "copy_name": "{name} (copia)",
         "copy_plans": "Copia i piani",
         "start_this_month": "Inizia da questo mese"
       },
@@ -1468,7 +1469,8 @@
       "invalid_role_alias": "Il ruolo di accesso al conto con alias {alias} non esiste",
       "invalid_code": "Il codice di collegamento non è corretto",
       "inviting_yourself": "Vuoi invitare te stesso?",
-      "deleting_yourself": "Vuoi eliminare te stesso?"
+      "deleting_yourself": "Vuoi eliminare te stesso?",
+      "invite_not_found": "Il codice di invito non è valido o è scaduto."
     },
     "currency": {
       "already_exists": "La valuta esiste già",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -853,6 +853,7 @@
       },
       "duplicate_budget_form": {
         "header": "Budget dupliceren",
+        "copy_name": "{name} (kopie)",
         "copy_plans": "Plannen kopiëren",
         "start_this_month": "Vanaf deze maand starten"
       },
@@ -1468,7 +1469,8 @@
       "invalid_role_alias": "Een rekeningrol met alias {alias} bestaat niet.",
       "invalid_code": "De verbindingscode is onjuist.",
       "inviting_yourself": "Uzelf uitnodigen?",
-      "deleting_yourself": "Uzelf verwijderen?"
+      "deleting_yourself": "Uzelf verwijderen?",
+      "invite_not_found": "De uitnodigingscode is ongeldig of verlopen."
     },
     "currency": {
       "already_exists": "Deze valuta bestaat al.",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -853,6 +853,7 @@
       },
       "duplicate_budget_form": {
         "header": "Duplikuj budżet",
+        "copy_name": "{name} (kopia)",
         "copy_plans": "Kopiuj plany",
         "start_this_month": "Zacznij od tego miesiąca"
       },
@@ -1468,7 +1469,8 @@
       "invalid_role_alias": "Rola dostępu do konta o aliasie {alias} nie istnieje.",
       "invalid_code": "Nieprawidłowy kod połączenia.",
       "inviting_yourself": "Zapraszasz samego siebie?",
-      "deleting_yourself": "Usuwasz samego siebie?"
+      "deleting_yourself": "Usuwasz samego siebie?",
+      "invite_not_found": "Kod zaproszenia jest nieprawidłowy lub wygasł."
     },
     "currency": {
       "already_exists": "Taka waluta już istnieje.",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -853,6 +853,7 @@
       },
       "duplicate_budget_form": {
         "header": "Duplicar orçamento",
+        "copy_name": "{name} (cópia)",
         "copy_plans": "Copiar planos",
         "start_this_month": "Começar a partir deste mês"
       },
@@ -1468,7 +1469,8 @@
       "invalid_role_alias": "O papel de acesso à conta com o alias {alias} não existe.",
       "invalid_code": "O código de ligação está incorreto.",
       "inviting_yourself": "A convidar-se a si próprio?",
-      "deleting_yourself": "A eliminar-se a si próprio?"
+      "deleting_yourself": "A eliminar-se a si próprio?",
+      "invite_not_found": "O código de convite é inválido ou expirou."
     },
     "currency": {
       "already_exists": "A moeda já existe.",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -853,6 +853,7 @@
       },
       "duplicate_budget_form": {
         "header": "Дублировать бюджет",
+        "copy_name": "{name} (копия)",
         "copy_plans": "Копировать планы",
         "start_this_month": "Начать с этого месяца"
       },
@@ -1468,7 +1469,8 @@
       "invalid_role_alias": "Роль доступа к счёту с псевдонимом {alias} не существует.",
       "invalid_code": "Код подключения указан неверно.",
       "inviting_yourself": "Пригласить самого себя?",
-      "deleting_yourself": "Удалить самого себя?"
+      "deleting_yourself": "Удалить самого себя?",
+      "invite_not_found": "Код приглашения недействителен или истёк."
     },
     "currency": {
       "already_exists": "Такая валюта уже существует.",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -853,6 +853,7 @@
       },
       "duplicate_budget_form": {
         "header": "Дублювати бюджет",
+        "copy_name": "{name} (копія)",
         "copy_plans": "Копіювати плани",
         "start_this_month": "Почати з цього місяця"
       },
@@ -1468,7 +1469,8 @@
       "invalid_role_alias": "Роль доступу до рахунку з псевдонімом {alias} не існує.",
       "invalid_code": "Код підключення вказано невірно.",
       "inviting_yourself": "Запросити самого себе?",
-      "deleting_yourself": "Видалити самого себе?"
+      "deleting_yourself": "Видалити самого себе?",
+      "invite_not_found": "Код запрошення недійсний або прострочений."
     },
     "currency": {
       "already_exists": "Така валюта вже існує.",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -853,6 +853,7 @@
       },
       "duplicate_budget_form": {
         "header": "复制预算",
+        "copy_name": "{name}（副本）",
         "copy_plans": "复制计划",
         "start_this_month": "从本月开始"
       },
@@ -1468,7 +1469,8 @@
       "invalid_role_alias": "别名为 {alias} 的账户访问角色不存在。",
       "invalid_code": "邀请码不正确。",
       "inviting_yourself": "您不能邀请自己。",
-      "deleting_yourself": "您不能删除自己。"
+      "deleting_yourself": "您不能删除自己。",
+      "invite_not_found": "邀请码无效或已过期。"
     },
     "currency": {
       "already_exists": "该货币已存在。",

--- a/web/index.html
+++ b/web/index.html
@@ -30,7 +30,11 @@
         script.src = "/liltag.min.js";
         script.onload = function () {
           const lilTag = new LilTag(window.econumoConfig.LILTAG_CONFIG_URL);
-          lilTag.enableCache(parseInt(window.econumoConfig.LILTAG_CACHE_TTL));
+          // 0/unset means "no cache" — LilTag warns on non-positive TTLs
+          const ttl = parseInt(window.econumoConfig.LILTAG_CACHE_TTL);
+          if (ttl > 0) {
+            lilTag.enableCache(ttl);
+          }
           lilTag.init();
         };
         document.head.appendChild(script);

--- a/web/public/econumo-config.js
+++ b/web/public/econumo-config.js
@@ -1,5 +1,5 @@
 window.econumoConfig = {
-  LILTAG_CONFIG_URL: 'liltag-config.json',
+  LILTAG_CONFIG_URL: '/liltag-config.json',
   LILTAG_CACHE_TTL: 0,
   ALLOW_REGISTRATION: true,
   ANALYTICS: true,

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -20,6 +20,6 @@
   ],
   "theme_color": "#ffffff",
   "background_color": "#ffffff",
-  "start_url": "https://app.econumo.com",
+  "start_url": "/",
   "display": "standalone"
 }

--- a/web/src/features/accounts/AccountsSettingsPage.tsx
+++ b/web/src/features/accounts/AccountsSettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { DndContext, DragOverlay, KeyboardSensor, MeasuringStrategy, PointerSensor, closestCenter, useSensor, useSensors, useDroppable } from '@dnd-kit/core'
 import type { DragEndEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core'
 import { SortableContext, arrayMove, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
@@ -19,6 +20,7 @@ import { getItem, setItem } from '@/lib/storage'
 import { isNotEmpty, isValidFolderName } from '@/lib/validation'
 import { useIsCompact } from '@/hooks/useIsCompact'
 import { useUiStore } from '@/app/uiStore'
+import { queryKeys } from '@/app/queryKeys'
 import { RouterPage } from '@/app/router-pages'
 import type { AccountDto } from '@/api/dto/account'
 import type { FolderDto } from '@/api/dto/folder'
@@ -297,6 +299,7 @@ export function AccountsSettingsPage() {
   const [deleteAccountTarget, setDeleteAccountTarget] = useState<AccountDto | null>(null)
   const [declineAccountTarget, setDeclineAccountTarget] = useState<AccountDto | null>(null)
   const [previewAccount, setPreviewAccount] = useState<AccountDto | null>(null)
+  const queryClient = useQueryClient()
   const [accessAccountId, setAccessAccountId] = useState<string | null>(null)
   const [levelTarget, setLevelTarget] = useState<{ accountId: string; entry: ShareEntry } | null>(null)
 
@@ -485,6 +488,9 @@ export function AccountsSettingsPage() {
                             setDeclineAccountTarget(account)
                           }
                         } else if (action === 'access') {
+                          // grant state changes on the partner's device
+                          // (accept/decline) — refresh before showing it
+                          void queryClient.invalidateQueries({ queryKey: queryKeys.accounts })
                           setAccessAccountId(account.id)
                         } else {
                           setPreviewAccount(account)

--- a/web/src/features/accounts/queries.ts
+++ b/web/src/features/accounts/queries.ts
@@ -273,6 +273,14 @@ export function useAcceptAccountAccess() {
       void queryClient.invalidateQueries({ queryKey: queryKeys.folders })
       // the pre-accept cache excludes this account's transactions (pending = no access)
       void queryClient.invalidateQueries({ queryKey: queryKeys.transactions })
+      // access also unlocks the owner's classifications and custom currencies;
+      // without a refetch every shared transaction renders as "Uncategorized"
+      void queryClient.invalidateQueries({ queryKey: queryKeys.categories })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.tags })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.labels })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.payees })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.currencies })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.currencyRates })
       trackEvent(METRICS.CONNECTION_ACCEPT_ACCOUNT_ACCESS)
     },
   })

--- a/web/src/features/auth/LoginPage.test.tsx
+++ b/web/src/features/auth/LoginPage.test.tsx
@@ -203,3 +203,27 @@ it('reveals the server address field through the custom-server disclosure', asyn
   await user.click(screen.getByRole('button', { name: /custom server/i }))
   expect(screen.queryByLabelText('Server address')).not.toBeInTheDocument()
 })
+
+it('submits with the custom-server section collapsed and custom API allowed', async () => {
+  // Regression: register('host') runs even while the section is collapsed, so
+  // its rules must not block the submit when selfHosted is off — this used to
+  // silently swallow every login on a fresh self-hosted browser.
+  window.econumoConfig = { ALLOW_CUSTOM_API: 'true' }
+  const assign = vi.fn()
+  Object.defineProperty(window, 'location', { value: { ...window.location, assign }, writable: true })
+  server.use(
+    http.post('*/api/v1/user/login-user', () =>
+      HttpResponse.json({
+        user: { id: 'u1', name: 'Ada', email: 'a@b', avatar: '', options: [], currency: 'USD', reportPeriod: 'month' },
+        token: 'jwt',
+      }),
+    ),
+  )
+  const user = userEvent.setup()
+  renderLogin()
+  expect(screen.queryByLabelText('Server address')).not.toBeInTheDocument()
+  await user.type(screen.getByLabelText('Email'), 'ada@example.test')
+  await user.type(screen.getByLabelText('Password'), 'secret12')
+  await user.click(screen.getByRole('button', { name: /sign in/i }))
+  await vi.waitFor(() => expect(assign).toHaveBeenCalledWith('/'))
+})

--- a/web/src/features/auth/LoginPage.tsx
+++ b/web/src/features/auth/LoginPage.tsx
@@ -182,9 +182,13 @@ export function LoginPage() {
                 type="url"
                 placeholder={t('user.form.server_host.placeholder')}
                 {...register('host', {
+                  // register() runs on every render even while the section is
+                  // collapsed (react-hook-form keeps the field registered), so
+                  // the rules must pass when selfHosted is off — otherwise the
+                  // invisible empty field blocks every submit.
                   validate: {
-                    required: (v) => isNotEmpty(v) || t('user.form.server_host.validation.required_field'),
-                    url: (v) => isValidHttpUrl(v) || t('user.form.server_host.validation.invalid_url'),
+                    required: (v, values) => !values.selfHosted || isNotEmpty(v) || t('user.form.server_host.validation.required_field'),
+                    url: (v, values) => !values.selfHosted || isValidHttpUrl(v) || t('user.form.server_host.validation.invalid_url'),
                   },
                   onChange: (e: ChangeEvent<HTMLInputElement>) => config.backendHost(e.target.value),
                 })}

--- a/web/src/features/auth/RegistrationPage.test.tsx
+++ b/web/src/features/auth/RegistrationPage.test.tsx
@@ -102,3 +102,46 @@ it('stores the server address as it is typed', async () => {
   await user.type(host, 'https://my.box.test')
   expect(localStorage.getItem('backendHost')).toBe(JSON.stringify('https://my.box.test'))
 })
+
+it('submits with the custom-server section collapsed and custom API allowed', async () => {
+  // Regression: register('host') runs even while the section is collapsed, so
+  // its rules must not block the submit when selfHosted is off — this used to
+  // silently swallow every registration on a fresh self-hosted browser.
+  window.econumoConfig = { ALLOW_CUSTOM_API: 'true' }
+  server.use(
+    http.post('*/api/v1/user/register-user', () =>
+      HttpResponse.json({ success: true, message: '', data: { user: { id: 'u1', name: 'Ada', avatar: '' } } }),
+    ),
+  )
+  const user = userEvent.setup()
+  renderPage()
+  expect(screen.queryByLabelText('Server address')).not.toBeInTheDocument()
+  await user.type(screen.getByLabelText('Name'), 'Ada')
+  await user.type(screen.getByLabelText('Email'), 'ada@example.test')
+  await user.type(screen.getByLabelText('Password'), 'secret12')
+  await user.type(screen.getByLabelText('Confirm password'), 'secret12')
+  await user.click(screen.getByRole('button', { name: /sign up/i }))
+  expect(await screen.findByText('LOGIN PAGE')).toBeInTheDocument()
+})
+
+it("shows the server's reason when registration fails with one", async () => {
+  server.use(
+    http.post('*/api/v1/user/register-user', () =>
+      HttpResponse.json({ success: false, message: 'User already exists', code: 400, errors: {} }, { status: 400 }),
+    ),
+  )
+  const user = userEvent.setup()
+  renderPage()
+  await user.type(screen.getByLabelText('Name'), 'Ada')
+  await user.type(screen.getByLabelText('Email'), 'taken@example.test')
+  await user.type(screen.getByLabelText('Password'), 'secret12')
+  await user.type(screen.getByLabelText('Confirm password'), 'secret12')
+  await user.click(screen.getByRole('button', { name: /sign up/i }))
+  expect(await screen.findByText('User already exists')).toBeInTheDocument()
+})
+
+it('redirects to login when registration is disabled', async () => {
+  window.econumoConfig = { ALLOW_REGISTRATION: 'false' }
+  renderPage()
+  expect(await screen.findByText('LOGIN PAGE')).toBeInTheDocument()
+})

--- a/web/src/features/auth/RegistrationPage.tsx
+++ b/web/src/features/auth/RegistrationPage.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { FailDialog } from '@/components/FailDialog'
+import { apiErrorMessage } from '@/lib/apiError'
 import { PasswordInput } from '@/components/PasswordInput'
 import * as config from '@/lib/config'
 import { isNativeApp } from '@/lib/platform'
@@ -28,7 +29,7 @@ export function RegistrationPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const registerMutation = useRegister()
-  const [failOpen, setFailOpen] = useState(false)
+  const [failMessage, setFailMessage] = useState<string | null>(null)
   const customApiAllowed = config.isCustomApiAllowed()
 
   const { register, handleSubmit, setValue, getValues, watch, formState: { errors } } = useForm<RegistrationForm>({
@@ -66,8 +67,14 @@ export function RegistrationPage() {
   useEffect(() => {
     if (getToken()) {
       window.location.assign('/')
+      return
     }
-  }, [])
+    // the Sign-up tab is already disabled, but the URL still resolves —
+    // don't render a form whose submit the server will refuse
+    if (!config.isRegistrationAllowed()) {
+      navigate(RouterPage.LOGIN, { replace: true })
+    }
+  }, [navigate])
 
   const onSubmit = handleSubmit(async ({ name, email, password }) => {
     try {
@@ -77,8 +84,10 @@ export function RegistrationPage() {
       // account the user will sign in with.
       config.rememberedEmail(email)
       navigate(RouterPage.LOGIN)
-    } catch {
-      setFailOpen(true)
+    } catch (err) {
+      // The backend localizes the reason (e.g. a taken email) — show it
+      // instead of a generic apology.
+      setFailMessage(apiErrorMessage(err))
     }
   })
 
@@ -164,9 +173,13 @@ export function RegistrationPage() {
                 type="url"
                 placeholder={t('user.form.server_host.placeholder')}
                 {...register('host', {
+                  // register() runs on every render even while the section is
+                  // collapsed (react-hook-form keeps the field registered), so
+                  // the rules must pass when selfHosted is off — otherwise the
+                  // invisible empty field blocks every submit.
                   validate: {
-                    required: (v) => isNotEmpty(v) || t('user.form.server_host.validation.required_field'),
-                    url: (v) => isValidHttpUrl(v) || t('user.form.server_host.validation.invalid_url'),
+                    required: (v, values) => !values.selfHosted || isNotEmpty(v) || t('user.form.server_host.validation.required_field'),
+                    url: (v, values) => !values.selfHosted || isValidHttpUrl(v) || t('user.form.server_host.validation.invalid_url'),
                   },
                   onChange: (e: ChangeEvent<HTMLInputElement>) => config.backendHost(e.target.value),
                 })}
@@ -179,10 +192,10 @@ export function RegistrationPage() {
         </form>
 
         <FailDialog
-          open={failOpen}
-          onClose={() => setFailOpen(false)}
+          open={failMessage !== null}
+          onClose={() => setFailMessage(null)}
           title={t('auth.sign_up_failed.header')}
-          description={t('auth.sign_up_failed.information')}
+          description={failMessage ?? t('auth.sign_up_failed.information')}
         />
       </div>
     </>

--- a/web/src/features/budgets/BudgetPage.test.tsx
+++ b/web/src/features/budgets/BudgetPage.test.tsx
@@ -61,8 +61,9 @@ it('renders the full budget page: strip, chips, table, totals', async () => {
   )
   renderPage()
   expect(await screen.findByText('Main budget')).toBeInTheDocument()
-  // 47 period-strip month tabs + the Budget/Plan mode toggle's 2 tabs
-  expect(screen.getAllByRole('tab')).toHaveLength(49)
+  // period strip is clamped at the budget start (Jan..selected+23 = 30 month
+  // tabs) + the Budget/Plan mode toggle's 2 tabs
+  expect(screen.getAllByRole('tab')).toHaveLength(32)
   expect(await screen.findByTestId('budget-folder-Essentials')).toBeInTheDocument()
   expect(screen.getByTestId('budget-totals')).toBeInTheDocument()
   // currency chips from balances

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -1,4 +1,6 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/app/queryKeys";
 import {
   Bookmark,
   ChevronDown,
@@ -78,6 +80,7 @@ export function BudgetsPage() {
   const [declineTarget, setDeclineTarget] = useState<BudgetMetaDto | null>(
     null,
   );
+  const queryClient = useQueryClient();
   const [accessBudgetId, setAccessBudgetId] = useState<string | null>(null);
   const [levelEntry, setLevelEntry] = useState<ShareEntry | null>(null);
   const [errorOpen, setErrorOpen] = useState(false);
@@ -119,7 +122,7 @@ export function BudgetsPage() {
               ? `default budget ${budget.name}`
               : `set default ${budget.name}`
           }
-          disabled={isDefault || !accepted}
+          disabled={isDefault || !accepted || budget.isArchived === 1}
           className="text-muted-foreground disabled:opacity-100"
           onClick={() => updateDefaultBudget.mutate(budget.id)}
         >
@@ -166,7 +169,13 @@ export function BudgetsPage() {
               </DropdownMenuItem>
             ) : null}
             {user && hasBudgetAdminAccess(budget, user.id) ? (
-              <DropdownMenuItem onSelect={() => setAccessBudgetId(budget.id)}>
+              <DropdownMenuItem
+                onSelect={() => {
+                  // grant state changes on the partner's device — refresh first
+                  void queryClient.invalidateQueries({ queryKey: queryKeys.budgets });
+                  setAccessBudgetId(budget.id);
+                }}
+              >
                 {t("budgets.page.settings.list_actions.access")}
               </DropdownMenuItem>
             ) : null}

--- a/web/src/features/budgets/DuplicateBudgetDialog.tsx
+++ b/web/src/features/budgets/DuplicateBudgetDialog.tsx
@@ -26,12 +26,14 @@ export function DuplicateBudgetDialog({ budget, onClose }: DuplicateBudgetDialog
 
   useEffect(() => {
     if (budget) {
-      setName(budget.name)
+      // pre-filling the identical name is one Enter away from two
+      // indistinguishable budgets — suffix the copy
+      setName(t('budgets.modal.duplicate_budget_form.copy_name', { name: budget.name }))
       setCopyPlans(true)
       setStartThisMonth(false)
       setError(undefined)
     }
-  }, [budget])
+  }, [budget, t])
 
   const submit = () => {
     if (!budget) return

--- a/web/src/features/budgets/PeriodStrip.test.tsx
+++ b/web/src/features/budgets/PeriodStrip.test.tsx
@@ -14,29 +14,44 @@ beforeEach(() => {
   useBudgetPeriodStore.setState({ selectedDate: '2026-07-01', unfoldedElements: {}, foldBudgetId: null })
 })
 
-it('strip renders 47 chips, marks active and dims pre-start months; click sets the period', async () => {
+it('strip clamps at the start month, marks active; click sets the period', async () => {
   const user = userEvent.setup()
   render(<PeriodStrip startedAt="2026-01-01 00:00:00" />)
+  // months before the budget start are not offered (Jan..Jul + 23 ahead)
   const tabs = screen.getAllByRole('tab')
-  expect(tabs).toHaveLength(47)
+  expect(tabs[0]).toHaveTextContent('January')
+  expect(screen.queryByRole('tab', { name: 'Dec 2025' })).not.toBeInTheDocument()
   expect(screen.getByRole('tab', { selected: true })).toHaveTextContent('July')
-  await user.click(screen.getByRole('tab', { name: 'Dec 2025' }))
-  expect(useBudgetPeriodStore.getState().selectedDate).toBe('2025-12-01')
+  await user.click(screen.getByRole('tab', { name: 'March' }))
+  expect(useBudgetPeriodStore.getState().selectedDate).toBe('2026-03-01')
 })
 
-it('strip extends the window when scrolled near either edge', () => {
+it('strip clamps at the end month for an ended budget but keeps the active tab', () => {
+  useBudgetPeriodStore.setState({ selectedDate: '2026-09-01' })
+  render(<PeriodStrip startedAt="2026-01-01 00:00:00" endedAt="2026-08-01 00:00:00" />)
+  // Sep is only shown because it is the (stale) selection; Oct+ are gone
+  expect(screen.getByRole('tab', { selected: true })).toHaveTextContent('September')
+  expect(screen.queryByRole('tab', { name: 'October' })).not.toBeInTheDocument()
+  const tabs = screen.getAllByRole('tab')
+  expect(tabs[0]).toHaveTextContent('January')
+})
+
+it('strip extends the window forward but never past the budget bounds', () => {
   render(<PeriodStrip startedAt="2026-01-01 00:00:00" />)
   const strip = screen.getByRole('tablist')
   Object.defineProperty(strip, 'clientWidth', { value: 800, configurable: true })
   Object.defineProperty(strip, 'scrollWidth', { value: 4000, configurable: true })
+  const initial = screen.getAllByRole('tab').length
 
+  // the left edge is already clamped at the start month — no extension
   strip.scrollLeft = 100
   fireEvent.scroll(strip)
-  expect(screen.getAllByRole('tab')).toHaveLength(47 + 12)
+  expect(screen.getAllByRole('tab')).toHaveLength(initial)
 
+  // open-ended budgets keep extending forward
   strip.scrollLeft = 3500
   fireEvent.scroll(strip)
-  expect(screen.getAllByRole('tab')).toHaveLength(47 + 24)
+  expect(screen.getAllByRole('tab')).toHaveLength(initial + 12)
   // the selected month is unchanged — only the rendered window grew
   expect(useBudgetPeriodStore.getState().selectedDate).toBe('2026-07-01')
 })

--- a/web/src/features/budgets/PeriodStrip.tsx
+++ b/web/src/features/budgets/PeriodStrip.tsx
@@ -17,7 +17,14 @@ export function PeriodStrip({ startedAt, endedAt = null }: { startedAt: string |
 
   const [extend, setExtend] = useState({ before: 0, after: 0 })
 
-  const items = periodRange(selectedDate, startedAt, MONTHS_AROUND + extend.before, MONTHS_AROUND + extend.after, i18n.language, endedAt)
+  const allItems = periodRange(selectedDate, startedAt, MONTHS_AROUND + extend.before, MONTHS_AROUND + extend.after, i18n.language, endedAt)
+  // The strip is clamped to the budget's lifetime: months before the start or
+  // past the end month are dead (the server clamps reads anyway), so they are
+  // not offered. The active month stays visible even when the stored selection
+  // points outside the window (e.g. a budget that ended before this month).
+  const items = allItems.filter((item) => !item.outsideBudget || item.isActive)
+  const canExtendBefore = allItems.length > 0 && !allItems[0].outsideBudget
+  const canExtendAfter = allItems.length > 0 && !allItems[allItems.length - 1].outsideBudget
 
   useLayoutEffect(() => {
     activeRef.current?.scrollIntoView({ inline: 'center', block: 'nearest' })
@@ -54,10 +61,10 @@ export function PeriodStrip({ startedAt, endedAt = null }: { startedAt: string |
     if (!el || el.clientWidth === 0) {
       return
     }
-    if (el.scrollLeft < EDGE_THRESHOLD_PX && prependAnchor.current === null) {
+    if (canExtendBefore && el.scrollLeft < EDGE_THRESHOLD_PX && prependAnchor.current === null) {
       prependAnchor.current = el.scrollWidth
       setExtend((e) => ({ ...e, before: e.before + EXTEND_STEP }))
-    } else if (el.scrollWidth - el.scrollLeft - el.clientWidth < EDGE_THRESHOLD_PX) {
+    } else if (canExtendAfter && el.scrollWidth - el.scrollLeft - el.clientWidth < EDGE_THRESHOLD_PX) {
       setExtend((e) => ({ ...e, after: e.after + EXTEND_STEP }))
     }
   }

--- a/web/src/features/budgets/queries.ts
+++ b/web/src/features/budgets/queries.ts
@@ -455,6 +455,13 @@ export function useAcceptBudgetAccess() {
       // accepting can change the default budget option + budget visibility
       void queryClient.invalidateQueries({ queryKey: queryKeys.user })
       void queryClient.invalidateQueries({ queryKey: queryKeys.budget })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.budgetPlan })
+      // access also unlocks the owner's classifications and custom currencies
+      // referenced by the budget's elements
+      void queryClient.invalidateQueries({ queryKey: queryKeys.categories })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.tags })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.currencies })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.currencyRates })
       trackEvent(METRICS.BUDGET_ACCEPT_ACCESS)
     },
   })

--- a/web/src/features/transactions/ImportResultDialog.test.tsx
+++ b/web/src/features/transactions/ImportResultDialog.test.tsx
@@ -29,7 +29,7 @@ it('partial success: both counts and error rows formatting', () => {
     ],
   })
   expect(screen.getByText('Import completed with errors')).toBeInTheDocument()
-  expect(screen.getByText('1 transaction(s) imported')).toBeInTheDocument()
+  expect(screen.getByText('1 transaction imported')).toBeInTheDocument()
   expect(screen.getByText('3 transactions failed')).toBeInTheDocument()
   expect(screen.getByText('Error details')).toBeInTheDocument()
   expect(screen.getByText(/Row 4/)).toBeInTheDocument()


### PR DESCRIPTION
Full manual regression of the app (two passes: exploratory + plan-driven), the resulting canonical test plan, and fixes for everything actionable the runs surfaced.

## Test plan

- `docs/regression-test-plan.md` — the manual regression checklist: all modules, desktop/tablet/mobile viewports, multi-user sharing scenarios, environment setup that neutralizes the repo `.env` (admin-port collision, email verification, data salt).
- CLAUDE.md rule: any change to user-observable behavior must update the affected checklist items in the same PR (this PR follows it — the fixed behaviors are reflected in the plan).
- The plan was validated by executing it verbatim; nine corrections from that dry run are included (fresh-DB custom-currency path, folder-delete semantics, recurring Post/Skip entry points, envelope entry point, full-screen mobile form sheets, environment-dependent items, …).

## Fixes

- **CRITICAL — login/registration silently no-op in a fresh browser when `ALLOW_CUSTOM_API` is on** (every self-hosted instance's default): the collapsed "Connect to a custom server" section's `host` field stays registered in react-hook-form, so its `required` rule invisibly failed every submit; no request, no error. The rules now pass while `selfHosted` is off. Regression tests cover both pages with the section collapsed (verified to fail on the old code) and the fix was re-verified end-to-end against the production build.
- Registration failures surface the server's localized reason (e.g. "User already exists") instead of a generic dialog.
- Accepting an account/budget share invalidates the classification + currency caches — the partner no longer sees every shared transaction as "Uncategorized" until a manual sync; the owner's share dialogs refetch grant state on open (stale "invitation pending" after a decline).
- Wrong/expired invitation codes answer a coded, localized "The invitation code is invalid or has expired." instead of the raw "ConnectionInvite not found" (`errors.connection.invite_not_found` added to all 11 catalogues).
- The budget period strip is clamped to the budget's lifetime — no more months before the start or past the end month, and edge-scrolling stops at the bounds.
- `/register` redirects to login when registration is disabled (the form used to render and only fail at submit).
- Duplicate-budget pre-fills "name (copy)" (localized) instead of the identical name; the set-default star is disabled on archived budgets; the English import-result singular no longer reads "1 transaction(s)".
- `liltag-config.json` loads via an absolute path (was 404ing on nested routes), the LilTag cache warning is silenced for the TTL=0 default, and the PWA manifest `start_url` is origin-relative so installs work on self-hosted origins.

Known findings deliberately **not** fixed here (product decisions): the "[Hidden account]" label on transfers to one's own deleted accounts (needs deleted accounts on the wire), and account deletion landing its balance as Uncategorized spending in the current budget month.

## Verification

- Web: 1119/1119 vitest (incl. 4 new regression tests), oxlint clean, production build OK.
- Go: `make go-test` green, coverage 80.7% (gate 80), no golden changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
