### PR TITLE
feat: send product analytics to Twillingate instead of PostHog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,7 @@ ECONUMO_ALLOW_REGISTRATION=true
 # Econumo releases (a single request from the server to econumo.com).
 # ECONUMO_CHECK_UPDATES=false
 
-# Optional: anonymous product analytics (PostHog). Each event carries only the
+# Optional: anonymous product analytics (Twillingate). Each event carries only the
 # event name, app version, UI language, a UUID-scrubbed route, and a
 # "self-hosted" marker — no account data, no hostnames, no cookies, and client
 # IPs are discarded at ingestion. Set false to disable for the whole instance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,7 +261,7 @@ vitest (`pnpm test`).
 
 **Product analytics rule:** every new user-facing feature/action MUST fire an
 analytics event — add a key to `METRICS` (`web/src/lib/metrics.ts`, frozen
-`app`-prefixed camelCase names; the PostHog snake_case name derives
+`app`-prefixed camelCase names; the collector's snake_case name derives
 automatically) and call `trackEvent` at the action's success point (mutation
 `onSuccess`; or inside `mutationFn` after the API call for hooks with a dedupe
 short-circuit, e.g. the classification creates). Prefer the shared hook/store
@@ -432,7 +432,7 @@ The Go server reads its environment from `.env` (see `.env.example`). Key vars:
   just works). A configured origin is reflected back with `Vary: Origin`; `*` allows any origin.
 - `ECONUMO_CURRENCY_BASE` — base currency (default `USD`).
 - `ECONUMO_CHECK_UPDATES` — daily check for new releases against `econumo.com/releases/latest.json` (single server-side request; result served to the SPA via `get-update-info`). `false` disables it.
-- `ECONUMO_ANALYTICS` — anonymous product analytics from the SPA to PostHog (default `true`).
+- `ECONUMO_ANALYTICS` — anonymous product analytics from the SPA to Twillingate (default `true`).
   `false` disables it instance-wide. Malformed values fail at boot (strict parse, unlike
   the other booleans). Server-owned SPA config keys reach the frontend via an
   `Object.assign(window.econumoConfig, …)` line the SPA handler appends to the served

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	DataSalt                   string // ECONUMO_DATA_SALT. DEPRECATED and IGNORED by the API/repositories (they run salt-free); consumed only by the data:remove-salt migration to decrypt existing data. Unset it after migrating.
 	SQLiteBusyTimeout          int
 	CheckUpdates               bool // ECONUMO_CHECK_UPDATES: poll econumo.com for the latest release (default true)
-	Analytics                  bool // ECONUMO_ANALYTICS: SPA sends anonymous product events to PostHog (default true)
+	Analytics                  bool // ECONUMO_ANALYTICS: SPA sends anonymous product events to Twillingate (default true)
 	TrialDays                  int  // ECONUMO_TRIAL: length in days of the trial granted to a new self-service registration; 0 (default, also "none"/empty) grants no trial, i.e. permanent full access
 	EmailVerification          bool // ECONUMO_EMAIL_VERIFICATION: unverified users must confirm an emailed code at login (default false)
 	CurrencyUpdateIntervalDays int  // ECONUMO_CURRENCY_UPDATE_INTERVAL: days between in-process rate refreshes; 0 (default) = off (requires OPEN_EXCHANGE_RATES_TOKEN)

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -107,7 +107,7 @@ servers" — standard for self-hosting clients.
 ## Store submission checklist
 
 - App id `com.econumo.app` on both stores.
-- Privacy labels: declare PostHog product analytics (disabled instance-wide
+- Privacy labels: declare Twillingate product analytics (disabled instance-wide
   when the server sets `ECONUMO_ANALYTICS=false`); no ad tracking.
 - Review notes: include a demo account on Econumo Cloud so reviewers can
   sign in without registering.

--- a/web/src/lib/analytics.test.ts
+++ b/web/src/lib/analytics.test.ts
@@ -5,6 +5,9 @@ type AnalyticsModule = typeof import('./analytics')
 let analytics: AnalyticsModule
 let fetchMock: ReturnType<typeof vi.fn>
 
+const COLLECTOR = 'https://t.kuznetsov.dev/api/events'
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
 beforeEach(async () => {
   vi.useFakeTimers()
   fetchMock = vi.fn(() => Promise.resolve(new Response()))
@@ -18,7 +21,13 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-function sentPayload(call = 0): { api_key: string; batch: Array<Record<string, unknown>> } {
+interface Envelope {
+  key: string
+  attributes: Record<string, unknown>
+  events: Array<Record<string, unknown>>
+}
+
+function sentPayload(call = 0): Envelope {
   const init = fetchMock.mock.calls[call][1] as RequestInit
   return JSON.parse(init.body as string)
 }
@@ -36,33 +45,43 @@ describe('analyticsDomain', () => {
 })
 
 describe('capture', () => {
-  it('batches and flushes on the timer with the PostHog payload shape', () => {
-    analytics.capture('appTransactionCreate', { locale: 'en' })
+  it('batches and flushes on the timer with the collector envelope shape', () => {
+    analytics.capture('transaction_create', { locale: 'en' })
     expect(fetchMock).not.toHaveBeenCalled()
     vi.advanceTimersByTime(10_000)
     expect(fetchMock).toHaveBeenCalledTimes(1)
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
-    expect(url).toBe('https://us.i.posthog.com/batch/')
+    expect(url).toBe(COLLECTOR)
     expect(init.method).toBe('POST')
     expect(init.keepalive).toBe(true)
+    // text/plain keeps the POST CORS-simple (no preflight) and matches what
+    // sendBeacon sends for a string body, so both transports look identical.
+    expect(init.headers).toEqual({ 'Content-Type': 'text/plain' })
     const payload = sentPayload()
-    expect(payload.api_key).toMatch(/^phc_/)
-    expect(payload.batch).toHaveLength(1)
-    expect(payload.batch[0].event).toBe('appTransactionCreate')
-    expect(payload.batch[0].timestamp).toBeTruthy()
-    expect(payload.batch[0].properties).toMatchObject({
-      locale: 'en',
-      $process_person_profile: false,
-    })
+    expect(payload.key).toMatch(/^ak_/)
+    expect(payload.events).toHaveLength(1)
+    expect(payload.events[0].name).toBe('transaction_create')
+    expect(payload.events[0].ts).toBeTruthy()
+    expect(payload.events[0].attributes).toEqual({ locale: 'en' })
   })
 
-  it('uses one in-memory distinct_id per page load', () => {
+  it('gives every event its own id, so a replayed batch dedupes server-side', () => {
     analytics.capture('a')
     analytics.capture('b')
     vi.advanceTimersByTime(10_000)
-    const { batch } = sentPayload()
-    expect(batch[0].distinct_id).toBe(batch[1].distinct_id)
-    expect(batch[0].distinct_id).toMatch(/^[0-9a-f-]{36}$/)
+    const { events } = sentPayload()
+    expect(events[0].id).toMatch(UUID_RE)
+    expect(events[0].id).not.toBe(events[1].id)
+  })
+
+  it('uses one in-memory $install_id per page load', () => {
+    analytics.capture('a')
+    vi.advanceTimersByTime(10_000)
+    const first = sentPayload().attributes.$install_id
+    analytics.capture('b')
+    vi.advanceTimersByTime(10_000)
+    expect(sentPayload(1).attributes.$install_id).toBe(first)
+    expect(first).toMatch(UUID_RE)
     expect(document.cookie).toBe('')
     expect(localStorage.length).toBe(0)
   })
@@ -72,7 +91,7 @@ describe('capture', () => {
       analytics.capture(`event-${i}`)
     }
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(sentPayload().batch).toHaveLength(10)
+    expect(sentPayload().events).toHaveLength(10)
     // The timer was cleared by the size-triggered flush: nothing further goes out.
     vi.advanceTimersByTime(10_000)
     expect(fetchMock).toHaveBeenCalledTimes(1)
@@ -86,19 +105,21 @@ describe('capture', () => {
     // No unhandled rejection, and the queue restarts empty.
     analytics.capture('b')
     vi.advanceTimersByTime(10_000)
-    expect(sentPayload(1).batch).toHaveLength(1)
+    expect(sentPayload(1).events).toHaveLength(1)
   })
 
   // crypto.randomUUID exists only in secure contexts, so a self-hosted instance
   // reached over http://<lan-ip> does not have it (issue #197).
-  it('assigns a distinct_id in an insecure context, where crypto.randomUUID is absent', async () => {
+  it('assigns an $install_id in an insecure context, where crypto.randomUUID is absent', async () => {
     const getRandomValues = globalThis.crypto.getRandomValues.bind(globalThis.crypto)
     vi.stubGlobal('crypto', { getRandomValues })
     vi.resetModules()
     const insecure = await import('./analytics')
     insecure.capture('a')
     vi.advanceTimersByTime(10_000)
-    expect(sentPayload().batch[0].distinct_id).toMatch(/^[0-9a-f-]{36}$/)
+    const payload = sentPayload()
+    expect(payload.attributes.$install_id).toMatch(UUID_RE)
+    expect(payload.events[0].id).toMatch(UUID_RE)
   })
 
   it('sends the tail via sendBeacon when the tab hides', () => {
@@ -109,8 +130,8 @@ describe('capture', () => {
     document.dispatchEvent(new Event('visibilitychange'))
     expect(beacon).toHaveBeenCalledTimes(1)
     const [url, body] = beacon.mock.calls[0] as unknown as [string, string]
-    expect(url).toBe('https://us.i.posthog.com/batch/')
-    expect(JSON.parse(body).batch).toHaveLength(1)
+    expect(url).toBe(COLLECTOR)
+    expect(JSON.parse(body).events).toHaveLength(1)
     expect(fetchMock).not.toHaveBeenCalled()
     Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
   })

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1,28 +1,29 @@
-// PostHog capture transport — the only file that knows PostHog exists.
-// Anonymous by construction: the distinct_id is a random per-page-load value
-// held in memory (never persisted anywhere), and only the whitelisted
-// properties built by the caller ever leave the browser.
-// See docs/superpowers/specs/2026-07-17-posthog-analytics-design.md.
+// Twillingate capture transport — the only file that knows the collector exists.
+// Anonymous by construction: $install_id is a random per-page-load value held in
+// memory (never persisted anywhere), and only the whitelisted attributes built by
+// the caller ever leave the browser. The collector salts and daily-rotates the
+// id on its side, so nothing links a visitor across days.
+// Wire format: POST /api/events, one batch per flush.
 
-import { v4 as uuidv4 } from 'uuid'
+import { v4 as uuidv4, v7 as uuidv7 } from 'uuid'
 
-const POSTHOG_HOST = 'https://us.i.posthog.com'
-// A PostHog project API key is public by design (it can only ingest events).
-const POSTHOG_KEY = 'phc_nsMAM8nZ2N9Xh4PmCTuUpihHC2tHJnkMKKPdHxSHwDEk'
+const COLLECTOR_URL = 'https://t.kuznetsov.dev/api/events'
+// An ingest key is public by design (it can only ingest events).
+const INGEST_KEY = 'ak_be90b906b92397705359981ebced78ef'
 const FLUSH_AT = 10
 const FLUSH_INTERVAL_MS = 10_000
 
 interface CapturedEvent {
-  event: string
-  distinct_id: string
-  timestamp: string
-  properties: Record<string, unknown>
+  id: string
+  ts: string
+  name: string
+  attributes: Record<string, unknown>
 }
 
 // Not crypto.randomUUID: that one is secure-context-only, so it is missing on a
 // self-hosted instance served over plain http://<lan-ip>, and this module-level
 // call would take the whole SPA down there. uuid falls back to getRandomValues.
-const distinctId = uuidv4()
+const installId = uuidv4()
 let queue: CapturedEvent[] = []
 let timer: ReturnType<typeof setTimeout> | null = null
 
@@ -35,10 +36,12 @@ export function analyticsDomain(hostname: string = window.location.hostname): st
 
 export function capture(event: string, properties: Record<string, unknown> = {}): void {
   queue.push({
-    event,
-    distinct_id: distinctId,
-    timestamp: new Date().toISOString(),
-    properties: { ...properties, $process_person_profile: false },
+    // v7 so ids sort by time; supplying one at all is what makes a batch that
+    // was retried after a timeout land as a no-op instead of double-counting.
+    id: uuidv7(),
+    ts: new Date().toISOString(),
+    name: event,
+    attributes: properties,
   })
   if (queue.length >= FLUSH_AT) {
     flush()
@@ -55,7 +58,13 @@ function takeBatch(): string | null {
   if (queue.length === 0) {
     return null
   }
-  const body = JSON.stringify({ api_key: POSTHOG_KEY, batch: queue })
+  // The key travels in the body, not a header: sendBeacon cannot set headers,
+  // and beacons are the only transport that survives page teardown.
+  const body = JSON.stringify({
+    key: INGEST_KEY,
+    attributes: { $install_id: installId },
+    events: queue,
+  })
   queue = []
   return body
 }
@@ -65,13 +74,16 @@ function flush(): void {
   if (!body) {
     return
   }
-  void fetch(`${POSTHOG_HOST}/batch/`, {
+  void fetch(COLLECTOR_URL, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    // text/plain keeps the request CORS-simple, so no preflight round trip.
+    headers: { 'Content-Type': 'text/plain' },
     keepalive: true,
     body,
   }).catch(() => {
     // Dropped on purpose: analytics must never break or noisy-log the app.
+    // Dropping is also the correct retry policy — the collector treats every
+    // 4xx as a poison batch, and a failed flush is not worth a second one.
   })
 }
 
@@ -85,7 +97,7 @@ document.addEventListener('visibilitychange', () => {
     return
   }
   try {
-    navigator.sendBeacon(`${POSTHOG_HOST}/batch/`, body)
+    navigator.sendBeacon(COLLECTOR_URL, body)
   } catch {
     // Same policy as flush: drop silently.
   }

--- a/web/src/lib/metrics.test.ts
+++ b/web/src/lib/metrics.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { METRICS, posthogEventName, scrubbedPage, trackEvent, viewMode, setAnalyticsAccessState } from './metrics'
+import { METRICS, analyticsEventName, scrubbedPage, trackEvent, viewMode, setAnalyticsAccessState } from './metrics'
 import { capture } from './analytics'
 
 vi.mock('./analytics', async (importOriginal) => {
@@ -23,7 +23,7 @@ it('pushes the event with context to the dataLayer', () => {
   expect(entry.eventContext).toMatchObject({ selfHosted: false, locale: 'en' })
 })
 
-describe('PostHog capture', () => {
+describe('collector capture', () => {
   it('captures with the whitelisted properties only', () => {
     window.history.replaceState({}, '', '/budgets/01980e2c-1111-7000-8000-123456789abc/details')
     trackEvent(METRICS.TRANSACTION_CREATE, { secret: 'never-sent' })
@@ -54,7 +54,7 @@ describe('PostHog capture', () => {
   })
 })
 
-describe('posthogEventName', () => {
+describe('analyticsEventName', () => {
   it.each([
     ['appPageView', 'page_view'],
     ['appTransactionCreate', 'transaction_create'],
@@ -62,7 +62,7 @@ describe('posthogEventName', () => {
     ['appApiAccountOrderList', 'api_account_order_list'],
     ['appBudgetTransferEnvelopeBudget', 'budget_transfer_envelope_budget'],
   ])('%s -> %s', (metric, expected) => {
-    expect(posthogEventName(metric)).toBe(expected)
+    expect(analyticsEventName(metric)).toBe(expected)
   })
 })
 

--- a/web/src/lib/metrics.ts
+++ b/web/src/lib/metrics.ts
@@ -8,7 +8,7 @@ declare global {
 }
 
 // prefix "app" is required! These are the frozen dataLayer (GTM/liltag) names;
-// PostHog event names derive from them via posthogEventName().
+// collector event names derive from them via analyticsEventName().
 export const METRICS = {
   PAGE_VIEW: 'appPageView',
   USER_LOGIN: 'appUserLogin',
@@ -150,9 +150,9 @@ export function viewMode(width: number = window.innerWidth): 'mobile' | 'tablet'
   return 'desktop'
 }
 
-// PostHog names: the frozen dataLayer prefix+camelCase becomes snake_case,
+// Collector names: the frozen dataLayer prefix+camelCase becomes snake_case,
 // e.g. appUIModalTransactionOpen -> ui_modal_transaction_open.
-export function posthogEventName(metric: string): string {
+export function analyticsEventName(metric: string): string {
   return metric
     .replace(/^app/, '')
     .replace(/([A-Z]+)(?=[A-Z][a-z])/g, '$1_')
@@ -160,7 +160,7 @@ export function posthogEventName(metric: string): string {
     .toLowerCase()
 }
 
-// There is no PostHog SDK and no person profile to hang a super property on
+// There is no analytics SDK and no persisted profile to hang a default attribute on
 // (see lib/analytics.ts) — per-event accuracy comes from stamping the state
 // at capture time from this module-level value, refreshed wherever user data
 // lands (login, get-user-data).
@@ -192,7 +192,7 @@ export function trackEvent(metric: Metric, eventData: Record<string, unknown> = 
     const host = analyticsDomain()
     // The synthetic "self-hosted" host keeps real hostnames out of the URL;
     // only econumo.com domains appear verbatim.
-    capture(posthogEventName(metric), {
+    capture(analyticsEventName(metric), {
       host,
       self_hosted: host === 'self-hosted',
       locale: locale(),


### PR DESCRIPTION
Swaps the SPA's product-analytics vendor from PostHog to Twillingate. `web/src/lib/analytics.ts` remains the only file that knows a vendor exists.

## What changed

- **Transport** — `POST https://t.kuznetsov.dev/api/events` instead of PostHog's `/batch/`. The structure is unchanged: in-memory queue, flush at 10 events or 10s, `sendBeacon` tail on tab hide, silent drop on failure (which is also the collector's required retry policy — every 4xx is a poison batch).
- **Envelope** — the batch carries the ingest key and a per-page-load `$install_id` that the collector salts and rotates daily. Each event gets a uuidv7 `id`, so a batch retried after a timeout dedupes server-side instead of double-counting. Sent as `text/plain` to keep the request CORS-simple (no preflight) and identical to what `sendBeacon` emits for a string body.
- **Names** — event names and attributes are untouched, so the `METRICS` catalogue and every `trackEvent` call site carry over as-is. `posthogEventName` is renamed `analyticsEventName` with identical output.
- **`appPageView` deliberately stays the custom event `page_view`** rather than becoming `$pageview`: `app.econumo.com` already collects pageviews from the site snippet, and mapping it would double-count them.
- Prose renames in `.env.example`, `internal/config/config.go`, `CLAUDE.md`, `mobile/README.md`. `ECONUMO_ANALYTICS` is unchanged — it was already vendor-neutral.

## Collector-side config (already applied)

Project `app.econumo.com`, new ingest key labelled `spa` so the site snippet's key and the app bundle's key retire on separate schedules. `product_aggregation` enabled with breakdowns on `host`, `self_hosted`, `locale`, `version`, `mode`, `access_state`.

`allowed_origins` is set to `["*"]`. One SPA bundle ships one key but runs on many origins — Econumo Cloud, the demo instance, and every self-hosted install on an arbitrary hostname — and the collector 403s any `Origin` not on the project's allowlist. The wildcard keeps all of them reporting, exactly as PostHog does today, at the cost that anyone who lifts the public key can post events into this project. Verified after the change: `https://app.econumo.com`, `https://demo.econumo.com`, `http://192.168.7.42:8181` and `https://budget.example.org` all return 202.

## Testing

- `pnpm vitest run src/lib` — 236 passed. `analytics.test.ts` was rewritten for the new envelope: collector URL, `text/plain` header, per-event unique ids, one `$install_id` per page load with no cookie or `localStorage` written, size- and timer-triggered flushes, silent drop on rejection, `sendBeacon` on tab hide, and the insecure-context path where `crypto.randomUUID` is absent (#197).
- `pnpm lint` — 0 errors. `make go-lint` — build, vet, gofmt, swagger docs all clean.
- The envelope was validated against the live collector using a `$pageview` with no `$url`, which passes the origin and key checks and is then rejected by validation, so nothing was stored: key accepted, `$install_id` accepted with no "unknown reserved key" warning, from both a cloud and a LAN origin.
- `pnpm test` in full is 1119 passed / 1 failed. The failure is `src/api/transaction.test.ts` ("expected Blob to be an instance of Blob", a jsdom/undici realm mismatch); it fails identically on an untouched baseline checkout, so it is pre-existing and unrelated.

`docs/regression-test-plan.md` needs no update — nothing user-observable changed, and its only analytics reference is the vendor-neutral `ECONUMO_ANALYTICS=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)