### PR TITLE
fix: unrot two test suites pinned to a wall-clock date

### DIFF
--- a/internal/test/apiparity/catalogue_recurring.go
+++ b/internal/test/apiparity/catalogue_recurring.go
@@ -1,6 +1,12 @@
 package apiparity
 
 func init() {
+	// Every recurring occurrence here must stay ahead of the harness clock: a
+	// posted transaction dated today lands inside the account's "balance as of
+	// end of today" window and shifts the golden balances, so a hard-coded
+	// calendar date silently rots the goldens the day it arrives.
+	futureDate := ClockTime.AddDate(0, 1, 0).Format("2006-01-02 15:04:05")
+
 	register(Scenario{Name: "recurring_crud", Calls: func() []Call {
 		const opCreate = "e0000000-0000-0000-0000-0000000000a1"
 		var rtID string
@@ -9,7 +15,7 @@ func init() {
 				Body: map[string]any{
 					"id": opCreate, "type": "expense", "amount": "50.00",
 					"accountId": OwnerAccount, "categoryId": CatFood,
-					"schedule": "monthly", "nextPaymentAt": "2026-08-31 00:00:00",
+					"schedule": "monthly", "nextPaymentAt": futureDate,
 					"description": "rent",
 				}, CaptureIDInto: &rtID},
 			{Label: "list-after-create", Method: "GET", Path: "/api/v1/recurring/get-recurring-transaction-list", Auth: "owner"},
@@ -45,7 +51,7 @@ func init() {
 				Body: map[string]any{
 					"id": opCreate, "type": "expense", "amount": "50.00",
 					"accountId": OwnerAccount, "categoryId": CatFood,
-					"schedule": "monthly", "nextPaymentAt": "2026-08-31 00:00:00",
+					"schedule": "monthly", "nextPaymentAt": futureDate,
 					"description": "rent", "sourceTransactionId": &txID,
 				}},
 			{Label: "transaction-list-after-link", Method: "GET", Path: "/api/v1/transaction/get-transaction-list", Auth: "owner"},
@@ -61,14 +67,14 @@ func init() {
 				Body: map[string]any{
 					"id": opCreate, "type": "expense", "amount": "50.00",
 					"accountId": OwnerAccount, "categoryId": CatFood,
-					"schedule": "monthly", "nextPaymentAt": "2026-08-31 00:00:00",
+					"schedule": "monthly", "nextPaymentAt": futureDate,
 					"description": "rent",
 				}, CaptureIDInto: &rtID},
 			{Label: "post-recurring-transaction", Method: "POST", Path: "/api/v1/recurring/post-recurring-transaction", Auth: "owner",
 				Body: map[string]any{
 					"recurringId": &rtID, "id": opTx, "type": "expense", "amount": "50.00",
 					"accountId": OwnerAccount, "categoryId": CatFood,
-					"date": "2026-08-31 00:00:00", "description": "rent",
+					"date": futureDate, "description": "rent",
 				}},
 			{Label: "recurring-list-after-post", Method: "GET", Path: "/api/v1/recurring/get-recurring-transaction-list", Auth: "owner"},
 			{Label: "transaction-list-after-post", Method: "GET", Path: "/api/v1/transaction/get-transaction-list", Auth: "owner"},
@@ -90,7 +96,7 @@ func init() {
 			full := map[string]any{
 				"recurringId": &rtID, "id": opID, "type": "expense", "amount": "50.00",
 				"accountId": OwnerAccount, "categoryId": CatFood,
-				"date": "2026-08-31 00:00:00", "description": "rent",
+				"date": futureDate, "description": "rent",
 			}
 			for k, v := range body {
 				full[k] = v
@@ -102,7 +108,7 @@ func init() {
 				Body: map[string]any{
 					"id": opCreate, "type": "expense", "amount": "50.00",
 					"accountId": OwnerAccount, "categoryId": CatFood,
-					"schedule": "monthly", "nextPaymentAt": "2026-08-31 00:00:00",
+					"schedule": "monthly", "nextPaymentAt": futureDate,
 					"description": "rent", "labelIds": []string{LabelPersonal, LabelWork},
 				}, CaptureIDInto: &rtID},
 			post("post-inherits-template-labels", opInherit, nil),

--- a/web/src/features/budgets/PlanSheet.test.tsx
+++ b/web/src/features/budgets/PlanSheet.test.tsx
@@ -95,7 +95,14 @@ function usePlanHandlers() {
   )
 }
 
+// The plan fixtures span May-Aug 2026 and several cases read "today" straight
+// off the system clock: the default three-month window, the bold current-month
+// header, past-vs-future cell styling. Left on the real clock they quietly rot
+// the moment the calendar leaves that window. Only Date is faked, so
+// userEvent's and waitFor's real timers still run.
 beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] })
+  vi.setSystemTime(new Date(2026, 7, 15, 12, 0, 0))
   vi.clearAllMocks()
   localStorage.clear()
   window.econumoConfig = {}
@@ -110,6 +117,10 @@ beforeEach(() => {
     planFolds: {},
     planHideEmpty: false,
   })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
 })
 
 it('/plan renders the sheet: months, income on top, cells', async () => {


### PR DESCRIPTION
Two independent date time-bombs went off within hours of each other and turned CI red on **every** branch, `main` included. Neither is caused by any code change — see #228, whose dependency bump is innocent; its checks went red purely because the calendar moved.

## 1. Go — `apiparity` recurring goldens (broke 2026-08-31)

`catalogue_recurring.go` pinned every recurring occurrence to the literal `"2026-08-31 00:00:00"`, three weeks in the future when the goldens were recorded (#192, 2026-08-08). Account balance is "as of end of today in the caller's timezone", so the posted expense did not count. Once that date became today, it did:

```
want  "name":"Cash", ... "balance":"987.5"
got   "name":"Cash", ... "balance":"937.5"     # -50, exactly the posted amount
```

Fixed by deriving the date from the harness clock (`ClockTime.AddDate(0, 1, 0)`), so the occurrence stays a month ahead wherever and whenever the suite runs. **The goldens are unchanged** — the recorded behaviour was always "the occurrence is still in the future", so this restores it rather than re-baselining it.

## 2. Web — `PlanSheet.test.tsx` (broke 2026-09-01 UTC)

Three cases read "today" straight off the system clock — the default three-month window, the bold current-month header, past-vs-future cell styling — while the plan fixtures span May–Aug 2026. When the UTC clock entered September the window shifted to Aug/Sep/Oct, `plan-cell-pe1:1` stopped being August, and the current-month header left the rendered window.

Fixed by freezing the suite at 2026-08-15, the window the fixtures were authored against. Only `Date` is faked, so userEvent's and waitFor's real timers are untouched.

## Testing

- `make go-test` — SMOKE suite passes, total coverage 80.7% (min 80%).
- `go test ./internal/test/apiparity/ ./internal/test/mcpparity/` — both `ok`, no golden regeneration.
- `pnpm test` — 1123 tests, all green under `TZ=UTC` (the failure state before this change); `pnpm lint` and `tsc --noEmit` clean.
- PlanSheet's 83 cases verified across `UTC`, `America/Los_Angeles`, `Pacific/Kiritimati` (UTC+14), `Pacific/Niue` (UTC-11) and `Asia/Kolkata`.

Test-only, no user-observable behaviour changes, so `docs/regression-test-plan.md` needs no edit. Once this lands, #228 just needs a rebase to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)