### PR TITLE
chore: migrate to Go 1.27

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -39,7 +39,7 @@ jobs:
             CGO_ENABLED: "0"
             # Lock the go driver and its tools to the single SDK setup-go installs
             # (from go.mod). With 'auto', the runner's newer default Go can leak in
-            # via toolchain re-exec, mixing a 1.25 driver with 1.26-compiled objects
+            # via toolchain re-exec, mixing an older driver with objects compiled by the go.mod version
             # ("compile: version ... does not match go tool version ...").
             GOTOOLCHAIN: local
         steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/econumo/econumo
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Summary

- Bump the `go.mod` directive from `1.26.0` to `1.27.0`, matching the `golang:1.27-alpine` build image the Dockerfile already uses (#220).
- Make the CI `GOTOOLCHAIN: local` comment version-agnostic. CI itself reads the version from `go.mod`, so no workflow change was needed.

## Go 1.27 release-note items checked

- `encoding/json` is now backed by the v2 implementation. The apiparity and mcpparity goldens pass on both engines, so the frozen response envelope bytes are unchanged.
- No `//go:debug` / `godebug` settings in the repo, so the removed `asynctimerchan` and TLS GODEBUG knobs do not apply.
- No `compress/*` or `image/png` usage, so the changed flate output affects nothing.
- No tests depend on closure symbol names.
- The new default `stdversion` vet check in `go test` reports nothing.
- `go mod tidy` consolidation left the two require blocks as they were.

## Deliberately left out

`go fix ./...` under 1.27 proposes modernizer rewrites in 79 files (`errors.AsType`, range-over-int, `interface{}` to `any`). That is a stylistic sweep unrelated to the version bump and belongs in its own PR.

## Test plan

Run locally under go1.27.1:

- [x] `make go-test` (build, vet, gofmt, OpenAPI freshness, sqlite suite): 83.9% coverage
- [x] `make test-engines` against postgres:17-alpine: 196 comparisons, 0 skipped
- [x] `make test-repo-pgsql`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)