### PR TITLE
feat: split econumo-config.js VERSION into VERSION + VERSION_LABEL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,9 +78,3 @@ ECONUMO_ALLOW_REGISTRATION=true
 # On success, re-comment this line and `docker compose up -d`.
 # See docs/migration-v0-to-v1.md for the full walkthrough.
 # ECONUMO_DATA_SALT=
-
-# Version label shown in the UI (sidebar footer + settings row). Unset, the UI
-# shows the running binary's real version, which is what analytics and the
-# update check always report regardless of this value — set it only to relabel
-# a demo/staging instance.
-# ECONUMO_VERSION=demo

--- a/.env.example
+++ b/.env.example
@@ -78,3 +78,9 @@ ECONUMO_ALLOW_REGISTRATION=true
 # On success, re-comment this line and `docker compose up -d`.
 # See docs/migration-v0-to-v1.md for the full walkthrough.
 # ECONUMO_DATA_SALT=
+
+# Version label shown in the UI (sidebar footer + settings row). Unset, the UI
+# shows the running binary's real version, which is what analytics and the
+# update check always report regardless of this value — set it only to relabel
+# a demo/staging instance.
+# ECONUMO_VERSION=demo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,10 +260,16 @@ router, i18n setup), `lib/`, `locales/`, `test/`. Runtime config
 instance the Go server generates the whole document (see the "Web UI config"
 bullet below); `public/econumo-config.js` is only the static fallback used
 when there is no Go server in front of the SPA (the mobile app's bundled
-WebView, `pnpm dev` without a backend). The UI version label is
-`ECONUMO_VERSION`, inlined by Vite at build time (the Docker build arg of the
-same name sets it per image build, default `dev`). Lint is oxlint, tests are
-vitest (`pnpm test`).
+WebView, `pnpm dev` without a backend). Versions are two separate keys:
+`VERSION` is the real running version (`getVersion()` — every comparison:
+analytics `$app_version`, the update check, the query-cache buster, the mobile
+compatibility floors), `VERSION_LABEL` is the text the UI DISPLAYS
+(`getVersionLabel()` — the sidebar footer and the settings row, nothing else),
+set by the runtime `ECONUMO_VERSION` and falling back to `VERSION`. Vite also
+inlines a build-time `ECONUMO_VERSION` as the bundle's own version (the Docker
+build arg of the same name sets it per image build, default `dev`) — that one
+IS a real version, used by the mobile app where no server config is present.
+Lint is oxlint, tests are vitest (`pnpm test`).
 
 **Product analytics rule:** every new user-facing feature/action MUST fire an
 analytics event — add a key to `METRICS` (`web/src/lib/metrics.ts`, frozen
@@ -516,9 +522,12 @@ The Go server reads its environment from `.env` (see `.env.example`). Key vars:
   `ECONUMO_LILTAG_CONFIG_URL` (default `/liltag-config.json`; load liltag
   config from a URL instead of the bundled `liltag-config.json`),
   `ECONUMO_LILTAG_CACHE_TTL` (default the JS number `0`), and `ECONUMO_VERSION`
-  (UI version label; default `null`, resolved to the binary's
-  `internal/version.Version` before reaching the router, overridable for
-  demo/staging). `ANALYTICS` no longer exists as a config key — analytics is a
+  (`VERSION_LABEL`, the version text the UI DISPLAYS — set it to relabel a
+  demo/staging box; unset falls back to `VERSION`). `VERSION` itself has NO env
+  override: it always carries the binary's `internal/version.Version`, because
+  the SPA compares it as a real version (analytics `$app_version`, the update
+  check, the mobile app's compatibility floors), and a display label must never
+  reach those. `ANALYTICS` no longer exists as a config key — analytics is a
   per-user preference now, not instance-wide (see `ECONUMO_ANALYTICS` above).
   `INSTANCE_ID` is the one key with no matching env var: it carries the
   per-deployment digest (`internal/infra/instance`, resolved against the
@@ -529,7 +538,7 @@ The Go server reads its environment from `.env` (see `.env.example`). Key vars:
   `MIN_APP_VERSION` is the one key that stays conditional — omitted entirely
   when empty, since the app's version-check treats a present-but-empty value
   differently from an absent one. The composition root resolves the FS
-  (`web.DistFS`), version, and instance id once in `server.BuildAPI`.
+  (`web.DistFS`), both versions, and instance id once in `server.BuildAPI`.
   `web/public/econumo-config.js` itself is a fallback baseline, not a source
   of defaults for a served instance — it only matters for the mobile app's
   bundled WebView and `pnpm dev` without a backend running (see that file's

--- a/docs/regression-test-plan.md
+++ b/docs/regression-test-plan.md
@@ -354,7 +354,13 @@ User C sees none of it.
 - [ ] Update notices (environment-dependent — needs `ECONUMO_CHECK_UPDATES`
       and reachability of econumo.com): with a newer release available, the
       dismissible sidebar notice and the settings "update available" row
-      appear (simulate by pointing `ECONUMO_VERSION` at an old value).
+      appear (simulate with a binary built at an older version — Docker
+      `--build-arg ECONUMO_VERSION=v0.0.1`; the runtime variable no longer
+      moves this, it only relabels the UI).
+- [ ] Version label: with `ECONUMO_VERSION=demo-42` set at RUNTIME, the
+      sidebar footer and the settings version row both read `demo-42`, while
+      the update notice above still compares the real binary version (so a
+      current build shows no update prompt).
 - [ ] Readonly/trial gating (cloud only, `ECONUMO_TRIAL` set): expired user
       gets 402 toasts on writes, subscription banner shows; security actions
       (logout, password, sessions) still work.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,7 +81,7 @@ type Config struct {
 	AllowCustomAPI  *bool  // ECONUMO_ALLOW_CUSTOM_API
 	LiltagConfigURL string // ECONUMO_LILTAG_CONFIG_URL: URL the SPA loads liltag config from (empty = embedded liltag-config.json)
 	LiltagCacheTTL  string // ECONUMO_LILTAG_CACHE_TTL: liltag config cache TTL in seconds (empty = embedded default)
-	Version         string // ECONUMO_VERSION: overrides the UI version label (empty = the binary's build version)
+	Version         string // ECONUMO_VERSION: the version label the UI DISPLAYS (empty = the binary's build version); never the version the SPA compares
 }
 
 // isLoopbackHost reports whether a URL hostname is loopback ("localhost" or a

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -382,13 +382,11 @@ func Build(cfg config.Config, db *sql.DB, seams Seams) (http.Handler, http.Handl
 	)(webmcp.NewHandler(mcpRegister))
 
 	// The SPA is always embedded in the binary. The served econumo-config.js
-	// reports the running binary's version, overridable via ECONUMO_VERSION
-	// (handy for demo/staging environments).
+	// reports the running binary's version as VERSION; ECONUMO_VERSION only
+	// relabels what the UI DISPLAYS (VERSION_LABEL, handy for demo/staging
+	// environments), so a relabelled instance still reports its real version
+	// to analytics and to the mobile app's compatibility check.
 	spaFS, _ := web.DistFS()
-	spaVersion := cfg.Version
-	if spaVersion == "" {
-		spaVersion = version.Version
-	}
 	// Failure here must not stop the server: analytics are not load-bearing.
 	instanceID, err := instance.ID(context.Background(), db)
 	if err != nil {
@@ -402,7 +400,8 @@ func Build(cfg config.Config, db *sql.DB, seams Seams) (http.Handler, http.Handl
 		SupportedLanguages: i18n.Supported,
 		MCP:                mcpHandler,
 		SPA:                spaFS,
-		SPAVersion:         spaVersion,
+		SPAVersion:         version.Version,
+		SPAVersionLabel:    cfg.Version,
 		MinAppVersion:      compat.MinAppVersion,
 		InstanceID:         instanceID,
 	}), adminHandler, rateUpdater, nil

--- a/internal/web/router/router.go
+++ b/internal/web/router/router.go
@@ -88,11 +88,20 @@ type Deps struct {
 	SPA fs.FS
 
 	// SPAVersion is the version string merged into the served econumo-config.js
-	// as VERSION (the binary version, or the ECONUMO_VERSION override), resolved
-	// by the composition root. Empty is tolerated: VERSION is still emitted, as
-	// JSON null (never happens in production — server.BuildAPI always resolves
-	// a non-empty value).
+	// as VERSION: the running binary's own version, resolved by the composition
+	// root and never overridable, because the SPA compares it as a real version
+	// (analytics $app_version, the update check, the mobile app's compatibility
+	// floors). Empty is tolerated: VERSION is still emitted, as JSON null
+	// (never happens in production — server.BuildAPI always resolves a
+	// non-empty value).
 	SPAVersion string
+
+	// SPAVersionLabel is merged as VERSION_LABEL, the version text the UI
+	// DISPLAYS (the ECONUMO_VERSION override, handy for relabelling a
+	// demo/staging box). Empty falls back to SPAVersion, so the key is always
+	// present with a resolved value and a plain instance shows its real
+	// version.
+	SPAVersionLabel string
 
 	// MinAppVersion is merged into the served econumo-config.js as
 	// MIN_APP_VERSION — the oldest mobile-app build this backend accepts
@@ -178,12 +187,15 @@ func New(deps Deps) http.Handler {
 		liltagCacheTTL = deps.Cfg.LiltagCacheTTL
 	}
 	// The dist default is JS null. deps.SPAVersion is always non-empty in
-	// production (server.BuildAPI falls back to the binary version when
-	// ECONUMO_VERSION is unset), so an empty value here only happens when a
-	// caller builds Deps directly (tests).
+	// production (server.BuildAPI resolves the binary version), so an empty
+	// value here only happens when a caller builds Deps directly (tests).
 	var version any
 	if deps.SPAVersion != "" {
 		version = deps.SPAVersion
+	}
+	versionLabel := version
+	if deps.SPAVersionLabel != "" {
+		versionLabel = deps.SPAVersionLabel
 	}
 	overrides := map[string]any{
 		"ALLOW_REGISTRATION": deps.Cfg.AllowRegistration,
@@ -196,8 +208,9 @@ func New(deps Deps) http.Handler {
 		"LILTAG_CACHE_TTL":  liltagCacheTTL,
 		// Empty on a database that has not been migrated yet, in which case
 		// the SPA sends no instance identifier — matching the dist default.
-		"INSTANCE_ID": deps.InstanceID,
-		"VERSION":     version,
+		"INSTANCE_ID":   deps.InstanceID,
+		"VERSION":       version,
+		"VERSION_LABEL": versionLabel,
 	}
 	// MIN_APP_VERSION is the one key that stays conditional: the app's
 	// version-check treats a present-but-empty value differently from an

--- a/internal/web/router/router_test.go
+++ b/internal/web/router/router_test.go
@@ -221,8 +221,8 @@ func TestRuntimeConfigOverrides(t *testing.T) {
 	// The document is now generated ENTIRELY by the router (no merge against
 	// the dist file), so every key is present: the ones explicitly set above,
 	// plus every other key at its default (LILTAG_CONFIG_URL, LILTAG_CACHE_TTL,
-	// INSTANCE_ID, VERSION) and MIN_APP_VERSION because it was set.
-	want := `window.econumoConfig = {"ALLOW_CUSTOM_API":false,"ALLOW_REGISTRATION":false,"BILLING_URL":"https://pay.example.test/cloud/","INSTANCE_ID":"","LILTAG_CACHE_TTL":0,"LILTAG_CONFIG_URL":"/liltag-config.json","MIN_APP_VERSION":"v9.9.9","VERSION":null};`
+	// INSTANCE_ID, VERSION, VERSION_LABEL) and MIN_APP_VERSION because it was set.
+	want := `window.econumoConfig = {"ALLOW_CUSTOM_API":false,"ALLOW_REGISTRATION":false,"BILLING_URL":"https://pay.example.test/cloud/","INSTANCE_ID":"","LILTAG_CACHE_TTL":0,"LILTAG_CONFIG_URL":"/liltag-config.json","MIN_APP_VERSION":"v9.9.9","VERSION":null,"VERSION_LABEL":null};`
 	if !strings.Contains(body, want) {
 		t.Fatalf("config body missing %q:\n%s", want, body)
 	}
@@ -274,6 +274,7 @@ func TestRuntimeConfigOverrides_UnsetKeysGetDefaults(t *testing.T) {
 		`"LILTAG_CONFIG_URL":"/liltag-config.json"`,
 		`"LILTAG_CACHE_TTL":0`,
 		`"VERSION":null`,
+		`"VERSION_LABEL":null`,
 		`"INSTANCE_ID":""`,
 	} {
 		if !strings.Contains(body, want) {
@@ -309,7 +310,8 @@ func TestRuntimeConfigOverrides_InstanceID(t *testing.T) {
 
 // The liltag config URL and cache TTL are merged only when set, so a hosted
 // instance can point the SPA at a remote liltag config; VERSION carries the
-// running binary's version (or the ECONUMO_VERSION override).
+// running binary's version, and VERSION_LABEL falls back to it when no
+// display label was configured.
 func TestRuntimeConfigOverrides_LiltagAndVersion(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "econumo-config.js"), []byte("window.econumoConfig={};"), 0o644); err != nil {
@@ -333,7 +335,35 @@ func TestRuntimeConfigOverrides_LiltagAndVersion(t *testing.T) {
 		`"LILTAG_CONFIG_URL":"https://cdn.example/liltag.json"`,
 		`"LILTAG_CACHE_TTL":"3600"`,
 		`"VERSION":"v9.9.9"`,
+		`"VERSION_LABEL":"v9.9.9"`,
 	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("config body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+// VERSION_LABEL is display-only and independent of VERSION: ECONUMO_VERSION
+// relabels the UI for a demo/staging box, while VERSION keeps reporting the
+// real binary so analytics, the update check and the mobile app's
+// compatibility floors never compare against a made-up label.
+func TestRuntimeConfigOverrides_VersionLabelIsIndependentOfVersion(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "econumo-config.js"), []byte("window.econumoConfig={};"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := router.New(router.Deps{
+		SPA:             os.DirFS(dir),
+		SPAVersion:      "v1.2.3",
+		SPAVersionLabel: "demo-42",
+	})
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	resp := get(t, srv, http.MethodGet, "/econumo-config.js")
+	defer resp.Body.Close()
+	body := readBody(t, resp)
+	for _, want := range []string{`"VERSION":"v1.2.3"`, `"VERSION_LABEL":"demo-42"`} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("config body missing %q:\n%s", want, body)
 		}

--- a/web/public/econumo-config.js
+++ b/web/public/econumo-config.js
@@ -16,4 +16,5 @@ window.econumoConfig = {
   BILLING_URL: '',
   ALLOW_CUSTOM_API: true,
   VERSION: null,
+  VERSION_LABEL: null,
 };

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router'
 import { ChevronLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { UserAvatar } from '@/components/UserAvatar'
-import { getVersion, backendHost, getWebsiteUrl } from '@/lib/config'
+import { getVersionLabel, backendHost, getWebsiteUrl } from '@/lib/config'
 import { useAvailableUpdate } from '@/hooks/useAvailableUpdate'
 import { useIsCompact } from '@/hooks/useIsCompact'
 import { useNavigate } from 'react-router'
@@ -75,7 +75,7 @@ export function SettingsPage() {
   const [exportOpen, setExportOpen] = useState(false)
   const [importOpen, setImportOpen] = useState(false)
   const [importResult, setImportResult] = useState<AggregatedImportResult | null>(null)
-  const version = getVersion()
+  const version = getVersionLabel()
   const update = useAvailableUpdate()
   const access = useAccessState()
   const portal = useOpenBillingPortal()

--- a/web/src/lib/config.test.ts
+++ b/web/src/lib/config.test.ts
@@ -1,4 +1,4 @@
-import { getInstanceId, backendHost, selfHosted, locale, isCustomApiAllowed, isRegistrationAllowed, getVersion, getBillingUrl } from './config'
+import { getInstanceId, backendHost, selfHosted, locale, isCustomApiAllowed, isRegistrationAllowed, getVersion, getVersionLabel, getBillingUrl } from './config'
 
 beforeEach(() => {
   localStorage.clear()
@@ -45,8 +45,18 @@ describe('locale and version', () => {
     expect(locale()).toBe('en')
   })
 
-  it('prefers econumoConfig.VERSION for the version label', () => {
+  it('prefers econumoConfig.VERSION for the running version', () => {
     window.econumoConfig = { VERSION: 'v9.9.9' }
+    expect(getVersion()).toBe('v9.9.9')
+  })
+
+  it('reads the displayed label from VERSION_LABEL, falling back to VERSION', () => {
+    window.econumoConfig = { VERSION: 'v9.9.9' }
+    expect(getVersionLabel()).toBe('v9.9.9')
+    window.econumoConfig = { VERSION: 'v9.9.9', VERSION_LABEL: 'demo-42' }
+    expect(getVersionLabel()).toBe('demo-42')
+    // The label never leaks back into the real version: analytics, the update
+    // check and the app's compatibility floors all read getVersion().
     expect(getVersion()).toBe('v9.9.9')
   })
 

--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -13,6 +13,7 @@ export interface EconumoConfig {
   ALLOW_REGISTRATION?: boolean | string
   ALLOW_CUSTOM_API?: boolean | string
   VERSION?: string
+  VERSION_LABEL?: string
   INSTANCE_ID?: string
   BILLING_URL?: string
   LILTAG_CONFIG_URL?: string
@@ -115,8 +116,20 @@ export function getWebsiteUrl(): string {
   return import.meta.env.WEBSITE_URL ?? 'https://econumo.com'
 }
 
+// The REAL version of whatever is running: the server's binary version for a
+// server-served SPA, this build's own version in the mobile app. Everything
+// that COMPARES a version (analytics, the update check, the app's
+// compatibility floors, the query-cache buster) must read this, never the
+// display label, which ECONUMO_VERSION can set to arbitrary text.
 export function getVersion(): string {
   return window.econumoConfig?.VERSION || String(import.meta.env.ECONUMO_VERSION ?? 'dev')
+}
+
+// The version text the UI displays. A server sets VERSION_LABEL from
+// ECONUMO_VERSION to relabel a demo/staging instance; it always resolves to
+// something, falling back to the real version.
+export function getVersionLabel(): string {
+  return window.econumoConfig?.VERSION_LABEL || getVersion()
 }
 
 // The server merges BILLING_URL unconditionally into the served

--- a/web/src/lib/package.ts
+++ b/web/src/lib/package.ts
@@ -1,4 +1,4 @@
-import { getVersion } from './config'
+import { getVersionLabel } from './config'
 
 export interface EconumoPackage {
   label: string
@@ -10,7 +10,7 @@ export interface EconumoPackage {
 // (and any future config reload) mutate it at runtime.
 export function econumoPackage(): EconumoPackage {
   return {
-    label: getVersion(),
+    label: getVersionLabel(),
     includesConnections: true,
     includesSharedAccess: true,
   }


### PR DESCRIPTION
`VERSION` in the served `econumo-config.js` was doing two jobs: reporting the running binary *and* carrying the `ECONUMO_VERSION` display override. A relabelled demo/staging box therefore fed arbitrary text into every consumer that **compares** a version.

## The split

| key | value | consumers |
|---|---|---|
| `VERSION` | `internal/version.Version`, **no env override** | analytics `$app_version`, `useAvailableUpdate`, the query-cache buster, the mobile app's `serverVersion` compat floor |
| `VERSION_LABEL` | `ECONUMO_VERSION`, falling back to `VERSION` | the settings version row and the sidebar footer — nothing else |

Both keys are always present, matching the router's "every key ships with its default" rule. A plain instance is unchanged: with `ECONUMO_VERSION` unset, `VERSION_LABEL` resolves to the same real version.

On the SPA side `getVersion()` keeps its meaning (the real running version) and a new `getVersionLabel()` serves the two display sites. `appConfig.ts`'s `MERGED_KEYS` allowlist is untouched — the mobile app keeps showing its own build version, not the backend's label.

## Behaviour change worth flagging

`docs/regression-test-plan.md` told testers to simulate an available update by pointing `ECONUMO_VERSION` at an old value. That no longer works — the update check reads the real binary version now. The item now calls for a binary built at an older version (`--build-arg ECONUMO_VERSION=v0.0.1`, which sets the ldflags version), and a new item covers the runtime label.

Note the two meanings of `ECONUMO_VERSION` are now genuinely different: at **build** time (Docker build arg / Vite inline) it sets the real version; at **runtime** it only relabels the UI. Documented in the CLAUDE.md frontend bullet.

## Testing

- `make go-test` passes, 83.9% coverage. New `TestRuntimeConfigOverrides_VersionLabelIsIndependentOfVersion` asserts the label never leaks into `VERSION`; the three existing served-config assertions gained the new key.
- `web/src/lib/config.test.ts` covers the `VERSION_LABEL` → `VERSION` fallback and that the label does not leak back.
- `make web-lint` clean. `make web-test`: 1161/1162 pass — the one failure is the pre-existing `src/api/transaction.test.ts` cross-realm `Blob` `instanceof` mismatch, unrelated to this diff (no transaction or API-client file is touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)