### PR TITLE
feat: pin due recurring rows to today and post them dated today

### DIFF
--- a/docs/regression-test-plan.md
+++ b/docs/regression-test-plan.md
@@ -132,6 +132,12 @@ navigation (single-pane vs sidebar).
       search filters the list; virtualized scroll stays smooth with 100+ rows
       (seed them via CSV import — a generated 100+-row file doubles as the
       import-at-scale test).
+- [ ] Not-posted recurring entries due today or overdue lead the "today" group,
+      above today's real transactions, however far in the past they were due —
+      so opening the account puts them first on screen. They stay dimmed with
+      the red "not posted" note; templates due in the FUTURE keep their own day
+      group above the fold. With no transactions today at all, the pinned rows
+      still open a "today" group of their own.
 - [ ] Mobile: FAB adds a transaction; row tap opens the preview bottom sheet.
 
 ## 5. Transactions
@@ -167,9 +173,13 @@ navigation (single-pane vs sidebar).
       from Settings → Recurring): type, amount, schedule, accounts, category.
 - [ ] Due occurrence appears on the account page as "not posted". Post from the
       account-page row preview posts immediately (dated today); Post from
-      Settings → Recurring opens a pre-filled review dialog (scheduled date)
-      that you confirm. Both advance the schedule. Skip (advances without
-      posting) is offered ONLY on the account-page row preview.
+      Settings → Recurring opens a pre-filled review dialog that you confirm.
+      Both advance the schedule. Skip (advances without posting) is offered
+      ONLY on the account-page row preview.
+- [ ] Post an OVERDUE occurrence (schedule date in the past) both ways: the
+      created transaction is dated TODAY, not at the missed date, and lands in
+      today's group. The review dialog's date chip likewise pre-fills today —
+      a template still ahead of schedule keeps pre-filling its scheduled date.
 - [ ] Month-end clamping (31st → Feb 28 → Mar 31) is long-horizon — covered by
       unit tests; in a manual run just note the next-date math looks right.
 - [ ] Edit and delete a rule; delete asks for confirmation; posted transactions

--- a/web/src/features/accounts/AccountPage.test.tsx
+++ b/web/src/features/accounts/AccountPage.test.tsx
@@ -337,7 +337,14 @@ it('posts a due template straight from the preview, without the transaction form
   await user.click(await screen.findByRole('button', { name: 'Post' }))
 
   await waitFor(() => expect(posted).not.toBeNull())
-  expect(posted).toMatchObject({ recurringId: 'r1', amount: '9.99', accountId: 'a1', date: template.nextPaymentAt })
+  expect(posted).toMatchObject({ recurringId: 'r1', amount: '9.99', accountId: 'a1' })
+  // catching up on a missed schedule moves the money TODAY, so the posted row
+  // is dated now rather than at the date it was originally due
+  expect(posted!.date).not.toBe(template.nextPaymentAt)
+  // local, not UTC: the payload is built with the browser's local clock
+  const now = new Date()
+  const localToday = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
+  expect(posted!.date).toMatch(new RegExp(`^${localToday} `))
   // the prefilled form is what this flow replaced: posting must not open it
   expect(useUiStore.getState().transactionModal).toBeNull()
   expect(screen.queryByRole('dialog')).toBeNull()

--- a/web/src/features/recurring/postPayload.test.ts
+++ b/web/src/features/recurring/postPayload.test.ts
@@ -14,12 +14,18 @@ const template = (overrides: Partial<RecurringDto> = {}): RecurringDto => ({
 })
 
 it('posts an expense with the template amount, date and classifications', () => {
-  const payload = recurringPostPayload(template(), accounts, exchangeFn)
-  expect(payload).toMatchObject({
-    recurringId: 'r1', type: 'expense', accountId: 'a1', amount: '50.5',
-    categoryId: 'cat-food', payeeId: 'p1', tagId: 'tg1', description: 'rent',
-    date: '2026-08-02 00:00:00', accountRecipientId: null, amountRecipient: null,
-  })
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2026, 7, 2, 14, 30, 45))
+  try {
+    const payload = recurringPostPayload(template(), accounts, exchangeFn)
+    expect(payload).toMatchObject({
+      recurringId: 'r1', type: 'expense', accountId: 'a1', amount: '50.5',
+      categoryId: 'cat-food', payeeId: 'p1', tagId: 'tg1', description: 'rent',
+      date: '2026-08-02 14:30:45', accountRecipientId: null, amountRecipient: null,
+    })
+  } finally {
+    vi.useRealTimers()
+  }
 })
 
 it('omits labelIds so the server inherits the template\'s labels', () => {
@@ -41,12 +47,23 @@ it('posts a future-dated template as now instead of its scheduled date', () => {
   }
 })
 
-it('keeps the scheduled date when the template is due today', () => {
+it('posts a template due today as now rather than at midnight', () => {
   vi.useFakeTimers()
   vi.setSystemTime(new Date(2026, 7, 20, 14, 30, 45))
   try {
     const payload = recurringPostPayload(template({ nextPaymentAt: '2026-08-20 00:00:00' }), accounts, exchangeFn)
-    expect(payload.date).toBe('2026-08-20 00:00:00')
+    expect(payload.date).toBe('2026-08-20 14:30:45')
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+it('posts an overdue template with today\'s date, not its missed scheduled date', () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2026, 7, 20, 14, 30, 45))
+  try {
+    const payload = recurringPostPayload(template({ nextPaymentAt: '2026-06-15 00:00:00' }), accounts, exchangeFn)
+    expect(payload.date).toBe('2026-08-20 14:30:45')
   } finally {
     vi.useRealTimers()
   }

--- a/web/src/features/recurring/postPayload.ts
+++ b/web/src/features/recurring/postPayload.ts
@@ -1,7 +1,7 @@
 import { v7 as uuidv7 } from 'uuid'
 import type { AccountDto } from '@/api/dto/account'
 import type { PostRecurringPayload, RecurringDto } from '@/api/dto/recurring'
-import { formatDateTime, isFuture } from '@/lib/datetime'
+import { formatDateTime } from '@/lib/datetime'
 import { normalize } from '@/lib/decimal'
 
 /**
@@ -42,8 +42,9 @@ export function recurringPostPayload(
     // with no chip row to edit, so it asks the server to inherit the template's
     // labels rather than echoing a possibly-stale cached copy of them
     description: recurring.description || '',
-    // posting ahead of schedule means "pay it now": the money moves today, so a
-    // future scheduled date is clamped to the present rather than written as-is
-    date: isFuture(recurring.nextPaymentAt) ? formatDateTime(new Date()) : recurring.nextPaymentAt,
+    // Posting is the moment the money moves, so the transaction is always
+    // dated now — never at a schedule the user posted ahead of, and never at a
+    // missed one they are only catching up on today.
+    date: formatDateTime(new Date()),
   }
 }

--- a/web/src/features/transactions/TransactionDialog.test.tsx
+++ b/web/src/features/transactions/TransactionDialog.test.tsx
@@ -401,10 +401,16 @@ it('creates a category on the fly and selects it', async () => {
 })
 
 it('posting a recurring template: regular add dialog + date prefill, submits to post-recurring-transaction (not create-transaction)', async () => {
+  // relative to the real clock, not a hard-coded date: only a template still
+  // AHEAD of schedule prefills its own date, so a fixed date would silently
+  // change what this test covers once it slipped into the past
+  const due = new Date()
+  due.setDate(due.getDate() + 5)
+  const dueDay = `${due.getFullYear()}-${String(due.getMonth() + 1).padStart(2, '0')}-${String(due.getDate()).padStart(2, '0')}`
   const wireRecurringDto: RecurringDto = {
     id: 'r1', ownerUserId: 'u1', type: 'expense', accountId: 'a1', accountRecipientId: null,
     amount: '42.5', categoryId: 'cat-food', payeeId: null, tagId: null, labelIds: [], description: 'rent',
-    schedule: 'monthly', nextPaymentAt: '2026-07-05 00:00:00',
+    schedule: 'monthly', nextPaymentAt: `${dueDay} 00:00:00`,
   }
   let createCalled = false
   let postBody: Record<string, unknown> | undefined
@@ -431,7 +437,7 @@ it('posting a recurring template: regular add dialog + date prefill, submits to 
 
   // posting reads as the ordinary add dialog — the template only prefills it
   await screen.findByRole('heading', { name: 'Add transaction' })
-  expect(screen.getByRole('button', { name: 'date' })).toHaveTextContent('2026-07-05')
+  expect(screen.getByRole('button', { name: 'date' })).toHaveTextContent(dueDay)
   // the account list hasn't resolved yet at the moment the form seeds its
   // initial state (TransactionForm only mounts once the modal opens), so the
   // amount echoes normalizeNumber's un-padded value rather than the account's

--- a/web/src/features/transactions/useAccountTransactions.test.tsx
+++ b/web/src/features/transactions/useAccountTransactions.test.tsx
@@ -142,21 +142,56 @@ it('virtual transfer rows appear only on the source account', async () => {
   expect(resultA2.current.some((e) => e.kind === 'transaction' && e.transaction.id === 'r2')).toBe(false)
 })
 
-it('overdue templates surface at their past date', async () => {
+it('pins due and overdue templates to the head of today\'s group', async () => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  vi.setSystemTime(new Date(2026, 6, 2, 12, 0, 0))
+  const overdue = {
+    id: 'r-overdue', ownerUserId: 'u1', type: 'expense', accountId: 'a1', accountRecipientId: null,
+    amount: 12, categoryId: 'cat-food', payeeId: null, tagId: null, description: 'overdue rent',
+    schedule: 'monthly', nextPaymentAt: '2026-06-15 00:00:00',
+  }
+  const dueToday = { ...overdue, id: 'r-today', description: 'due today', nextPaymentAt: '2026-07-02 00:00:00' }
+  server.use(...coreHandlers({ recurring: [overdue, dueToday] }))
+  const { result } = renderHook(() => useAccountTransactions('a1', ''), { wrapper })
+  await waitFor(() => expect(result.current.some((e) => e.kind === 'transaction' && e.transaction.id === 'r-overdue')).toBe(true))
+
+  const kinds = result.current.map((e) => (e.kind === 'separator' ? `sep:${e.label}` : e.transaction.id))
+  // both unposted rows lead today's group, ahead of today's real transaction
+  expect(kinds).toEqual(['sep:today', 'r-today', 'r-overdue', 't1', 'sep:yesterday', 't2'])
+})
+
+it('keeps a pinned row\'s own date so posting still knows when it was due', async () => {
   vi.useFakeTimers({ shouldAdvanceTime: true })
   vi.setSystemTime(new Date(2026, 6, 2, 12, 0, 0))
   const rt = {
-    id: 'r3', ownerUserId: 'u1', type: 'expense', accountId: 'a1', accountRecipientId: null,
+    id: 'r-overdue', ownerUserId: 'u1', type: 'expense', accountId: 'a1', accountRecipientId: null,
     amount: 12, categoryId: 'cat-food', payeeId: null, tagId: null, description: 'overdue rent',
     schedule: 'monthly', nextPaymentAt: '2026-06-15 00:00:00',
   }
   server.use(...coreHandlers({ recurring: [rt] }))
   const { result } = renderHook(() => useAccountTransactions('a1', ''), { wrapper })
-  await waitFor(() => expect(result.current.some((e) => e.kind === 'transaction' && e.transaction.id === 'r3')).toBe(true))
+  await waitFor(() => expect(result.current.some((e) => e.kind === 'transaction' && e.transaction.id === 'r-overdue')).toBe(true))
 
-  const entries = result.current
-  const idx = entries.findIndex((e) => e.kind === 'transaction' && e.transaction.id === 'r3')
-  expect(entries[idx - 1]).toEqual({ kind: 'separator', day: '2026-06-15', label: 'date' })
+  const row = result.current.find((e) => e.kind === 'transaction' && e.transaction.id === 'r-overdue')
+  expect(row?.kind === 'transaction' && row.transaction.date).toBe('2026-06-15 00:00:00')
+})
+
+it('opens today\'s group for a pinned row even when today has no transactions', async () => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  // 07-03: every fixture transaction is now in the past
+  vi.setSystemTime(new Date(2026, 6, 3, 12, 0, 0))
+  const rt = {
+    id: 'r-overdue', ownerUserId: 'u1', type: 'expense', accountId: 'a1', accountRecipientId: null,
+    amount: 12, categoryId: 'cat-food', payeeId: null, tagId: null, description: 'overdue rent',
+    schedule: 'monthly', nextPaymentAt: '2026-06-15 00:00:00',
+  }
+  server.use(...coreHandlers({ recurring: [rt] }))
+  const { result } = renderHook(() => useAccountTransactions('a1', ''), { wrapper })
+  await waitFor(() => expect(result.current.some((e) => e.kind === 'transaction' && e.transaction.id === 'r-overdue')).toBe(true))
+
+  expect(result.current[0]).toEqual({ kind: 'separator', day: '2026-07-03', label: 'today' })
+  expect(result.current[1]).toMatchObject({ kind: 'transaction' })
+  expect(result.current[1].kind === 'transaction' && result.current[1].transaction.id).toBe('r-overdue')
 })
 
 it('title logic: no category, no description, no tag, no payee falls back to Uncategorized', () => {

--- a/web/src/features/transactions/useAccountTransactions.ts
+++ b/web/src/features/transactions/useAccountTransactions.ts
@@ -8,7 +8,7 @@ import type { TagDto } from '@/api/dto/tag'
 import type { TransactionDto } from '@/api/dto/transaction'
 import type { UserDto } from '@/api/dto/user'
 import type { Id } from '@/api/types'
-import { dayKey, formatDayHeading, isFuture, isToday, isYesterday } from '@/lib/datetime'
+import { dayKey, formatDate, formatDayHeading, isFuture, isToday, isYesterday } from '@/lib/datetime'
 import { useAccounts } from '@/features/accounts/queries'
 import { useCategories, useLabels, usePayees, useTags } from '@/features/classifications/queries'
 import { useRecurring } from '@/features/recurring/queries'
@@ -128,22 +128,43 @@ export function useAccountTransactions(accountId: Id | undefined, search: string
         recurringId: null,
         recurring: rt,
       }))
-    const merged = [...enriched, ...virtual].sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))
+    // A template that is due or overdue is money the user still has to act on,
+    // so it leads today's group instead of sitting at its own (possibly long
+    // past) date, where it reads as a transaction that already happened. The
+    // row keeps its real `date` — only the grouping and ordering move, so the
+    // preview and the post action still see when it was actually due.
+    const todayKey = formatDate(new Date())
+    const placed = [...enriched, ...virtual].map((tx) => {
+      const pinned = Boolean(tx.recurring) && !tx.isInFuture
+      return { tx, pinned, groupDay: pinned ? todayKey : dayKey(tx.date) }
+    })
+    placed.sort((a, b) => {
+      if (a.groupDay !== b.groupDay) {
+        return a.groupDay < b.groupDay ? 1 : -1
+      }
+      if (a.pinned !== b.pinned) {
+        return a.pinned ? -1 : 1
+      }
+      return a.tx.date < b.tx.date ? 1 : a.tx.date > b.tx.date ? -1 : 0
+    })
 
     const terms = search.toLowerCase().split(' ').filter(Boolean)
-    const filtered = terms.length === 0 ? merged : merged.filter((tx) => {
+    const filtered = terms.length === 0 ? placed : placed.filter(({ tx }) => {
       const hay = haystack(tx)
       return terms.every((term) => hay.includes(term))
     })
 
-    // already date-desc from the merge above; group by day
+    // already ordered by group above; emit one separator per group
     const entries: DailyListEntry[] = []
     let currentDay: string | null = null
-    for (const tx of filtered) {
-      const day = dayKey(tx.date)
-      if (day !== currentDay) {
-        currentDay = day
-        entries.push({ kind: 'separator', day, label: isToday(day) ? 'today' : isYesterday(day) ? 'yesterday' : 'date' })
+    for (const { tx, groupDay } of filtered) {
+      if (groupDay !== currentDay) {
+        currentDay = groupDay
+        entries.push({
+          kind: 'separator',
+          day: groupDay,
+          label: isToday(groupDay) ? 'today' : isYesterday(groupDay) ? 'yesterday' : 'date',
+        })
       }
       entries.push({ kind: 'transaction', transaction: tx })
     }

--- a/web/src/features/transactions/useTransactionForm.test.ts
+++ b/web/src/features/transactions/useTransactionForm.test.ts
@@ -101,6 +101,28 @@ it('hydrates labelIds from a recurring template being posted', () => {
   expect(initialFormState({ postRecurring: rt }, [account({})], null).labelIds).toEqual(['l1'])
 })
 
+it('seeds the date with now when the template being posted is overdue', () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2026, 7, 20, 14, 30, 45))
+  const rt: RecurringDto = {
+    id: 'r1', ownerUserId: 'u1', type: 'expense', accountId: 'a1', accountRecipientId: null,
+    amount: '50', categoryId: 'cat1', payeeId: null, tagId: null, labelIds: [], description: 'rent',
+    schedule: 'monthly', nextPaymentAt: '2026-06-15 00:00:00',
+  }
+  expect(initialFormState({ postRecurring: rt }, [account({})], null).date).toBe('2026-08-20 14:30:45')
+})
+
+it('keeps the scheduled date when the template being posted is still in the future', () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2026, 7, 20, 14, 30, 45))
+  const rt: RecurringDto = {
+    id: 'r1', ownerUserId: 'u1', type: 'expense', accountId: 'a1', accountRecipientId: null,
+    amount: '50', categoryId: 'cat1', payeeId: null, tagId: null, labelIds: [], description: 'rent',
+    schedule: 'monthly', nextPaymentAt: '2026-09-01 00:00:00',
+  }
+  expect(initialFormState({ postRecurring: rt }, [account({})], null).date).toBe('2026-09-01 00:00:00')
+})
+
 describe('classificationChips', () => {
   const tag = (over: Partial<TagDto>): TagDto => ({
     id: 'tg1', ownerUserId: 'u1', name: 'vacation', icon: 'tag', position: 0, isArchived: 0, createdAt: '', updatedAt: '', ...over,

--- a/web/src/features/transactions/useTransactionForm.ts
+++ b/web/src/features/transactions/useTransactionForm.ts
@@ -7,7 +7,7 @@ import type { FolderDto } from '@/api/dto/folder'
 import type { Id } from '@/api/types'
 import type { OpenTransactionParams } from '@/app/uiStore'
 import type { ClassificationKind } from '@/lib/classificationKind'
-import { formatDateTime } from '@/lib/datetime'
+import { formatDateTime, isFuture } from '@/lib/datetime'
 import { moneyFormat } from '@/lib/money'
 import { evaluateFormula, sanitizeInput } from '@/lib/calculator'
 import { normalize, tryNormalize } from '@/lib/decimal'
@@ -54,7 +54,10 @@ export function initialFormState(params: OpenTransactionParams, accounts: Accoun
       // template's set and any toggle the user makes lands on the transaction
       labelIds: rt.labelIds ?? [],
       description: rt.description,
-      date: rt.nextPaymentAt,
+      // a missed schedule is caught up TODAY, so the date chip starts at now
+      // rather than at the past date the user is unlikely to want; a template
+      // still ahead of schedule keeps its own date for the user to confirm
+      date: isFuture(rt.nextPaymentAt) ? rt.nextPaymentAt : formatDateTime(new Date()),
     }
   }
   const tx = params.transaction


### PR DESCRIPTION
## Problem

An unposted recurring template that was due today or overdue sat in the account transaction list at its own scheduled date. A template missed three weeks ago was therefore buried three weeks down the list, dimmed grey — reading as a transaction that had already happened rather than as something still waiting to be acted on.

Posting one also wrote the transaction at the missed schedule date, so catching up on a late payment back-dated the money.

## What changed

**Due and overdue templates lead the Today group.** `useAccountTransactions` now derives a `groupDay` and a `pinned` flag per row: a virtual recurring row that is due or overdue (`recurring && !isInFuture` — `isFuture` is day-granular, so this is "today or earlier") groups under today; everything else keeps `dayKey(tx.date)`. Sorting is `groupDay` desc → pinned first → `date` desc, and one separator is emitted per `groupDay`. Opening an account therefore puts the pinned rows first on screen, above today's real transactions.

The row keeps its real `date`, so the preview and the post action still see when it was actually due. Templates due in the **future** are untouched — they keep their own day group above the fold. `AccountPage` needed no change: its scroll anchor already looks for the first separator `<= today`, which is now the Today group led by the pinned rows.

**Posting is dated today.** `recurringPostPayload` already clamped a *future* schedule to now ("posting ahead of schedule means pay it now"); extending that to a missed schedule leaves a single rule, so the branch is gone and the date is always now. The review dialog reached from Settings → Recurring pre-fills its date chip with today for an overdue template; a template still ahead of schedule keeps pre-filling its scheduled date, where the chip is visible and editable.

**No backend change.** `PostRecurringTransaction` advances the schedule via `rt.Advance(s.clock.Now())`, which steps `NextPaymentAt` from its own value and never reads the posted transaction's date.

## Testing

Tests were written first and all six watched to fail for the right reason before implementing.

- `useAccountTransactions.test.tsx` — due + overdue rows lead today's group ahead of today's transactions; a pinned row keeps its own date; the pinned rows open a Today group even when today has no transactions. The old `overdue templates surface at their past date` case asserted the behaviour being replaced and was rewritten.
- `postPayload.test.ts` — an overdue template posts at today's date, not its missed one; a template due today posts at now rather than midnight.
- `useTransactionForm.test.ts` — an overdue template seeds the form date with now; a future one keeps its scheduled date.
- `AccountPage.test.tsx` — the direct-post assertion now checks the posted row is dated today (local clock, not UTC) and explicitly *not* the scheduled date.

`docs/regression-test-plan.md` gains an account-page item for the pinned block and a recurring item for posting an overdue occurrence both ways.

### Results

- `pnpm test`: **1165 passed, 2 failed**. Both are unrelated to this branch — `exportTransactionList … resolves a Blob` in `src/api/transaction.test.ts` is the known pre-existing failure (file untouched here), and the `PlanSheet.test.tsx` Enter-key case was a 5s timeout under load that passes in isolation (verified).
- `tsc -b` clean; oxlint 0 errors, 23 pre-existing warnings.
- Go suite not run: no Go, locale, or API files changed.

## Notes

- The `TransactionDialog` date-prefill test hard-coded `nextPaymentAt: '2026-07-05'`, which has since slipped into the past. Under the new rule it would prefill today, so the test was about to silently cover the opposite case; it now computes a date five days out from the real clock.
- `Advance` steps one occurrence at a time, so a template three months overdue still reads as overdue after one post. Pre-existing behaviour, left alone — but it is why overdue rows can accumulate in the pinned block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)